### PR TITLE
Added $CANINE_DOCKER_ARGS for streaming

### DIFF
--- a/canine/test/test_localizer_batched.py
+++ b/canine/test/test_localizer_batched.py
@@ -305,7 +305,7 @@ class TestIntegration(unittest.TestCase):
                                 path = value.path
                                 if value.type == 'stream':
                                     src = path
-                                    path = localizer.reserve_path('jobs', str(jid), 'inputs', os.path.basename(os.path.abspath(src))).remotepath
+                                    path = os.path.join('$CANINE_STREAM_DIR', os.path.basename(os.path.abspath(src)))
                                     self.assertIn(
                                         'if [[ -e {dest} ]]; then rm {dest}; fi\n'
                                         'mkfifo {dest}\n'
@@ -329,6 +329,8 @@ class TestIntegration(unittest.TestCase):
                                     )
                                 if isinstance(path, PathType):
                                     path = path.remotepath
+                                if '$' in path:
+                                    path = path.replace('$', '\\$')
                                 self.assertRegex(
                                     setup_text,
                                     r'export {}=[\'"]?{}[\'"]?'.format(arg, path)

--- a/examples/gpu.yaml
+++ b/examples/gpu.yaml
@@ -1,7 +1,7 @@
 name: GPU Test and example
 script:
   - nvidia-smi
-  - sudo docker run --rm --runtime nvidia nvidia/cuda nvidia-smi
+  - sudo docker run --rm --runtime nvidia $CANINE_DOCKER_ARGS nvidia/cuda nvidia-smi
 inputs:
   dummy_input: h
 resources:

--- a/examples/rnaseqc.yaml
+++ b/examples/rnaseqc.yaml
@@ -1,6 +1,6 @@
 name: RNA-SeQC
 script:
-  - sudo docker run --rm -v $CANINE_ROOT:$CANINE_ROOT -v $CANINE_JOB_ROOT:/output gcr.io/broad-cga-aarong-gtex/rnaseqc rnaseqc $genes_gtf $bam_file output --coverage -vv
+  - sudo docker run --rm $CANINE_DOCKER_ARGS gcr.io/broad-cga-aarong-gtex/rnaseqc rnaseqc $genes_gtf $bam_file $CANINE_JOB_ROOT --coverage -vv
 resources:
   cpus-per-task: 1
   mem-per-cpu: 3072M


### PR DESCRIPTION
Streams will now create a temporary directory in `/tmp` and the fifo will be created there. The localizer also maintains a `$CANINE_DOCKER_ARGS` variable for each job which is used to ensure dockers can still work regardless of the job setup.

**Any scripts using docker should expand $CANINE_DOCKER_ARGS as part of their command**

Blocks #55 (That PR should use CANINE_DOCKER_ARGS after this merges)

Closes #58 