### PR TITLE
2 for 1 bugfixes

### DIFF
--- a/canine/backends/dummy/__init__.py
+++ b/canine/backends/dummy/__init__.py
@@ -333,6 +333,7 @@ class DummySlurmBackend(AbstractSlurmBackend):
         Kills all running containers
         """
         print("Cleaning up Slurm Cluster", self.controller.short_id)
+        self.invoke('chmod -R a+rwX /mnt/nfs')
         containers = self.workers
         if not self.debug:
             containers.append(self.controller)

--- a/canine/backends/dummy/controller.py
+++ b/canine/backends/dummy/controller.py
@@ -125,6 +125,7 @@ def main(network, nodes, cpus, mem):
     time.sleep(3)
     subprocess.check_call('sacctmgr --immediate add cluster local_slurm', shell=True)
     subprocess.check_call('slurmctld -vvvvv', shell=True)
+    subprocess.check_call('chmod -R 777 /mnt/nfs/clust_conf', shell=True)
     subprocess.check_call('touch /mnt/nfs/controller.ready', shell=True)
 
     # Now become bash

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -571,9 +571,11 @@ class AbstractLocalizer(abc.ABC):
                 'export CANINE_JOB_INPUTS="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'inputs')),
                 'export CANINE_JOB_ROOT="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'workspace')),
                 'export CANINE_JOB_SETUP="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'setup.sh')),
+                'export CANINE_JOB_LOCALIZATION="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'localization.sh')),
                 'export CANINE_JOB_TEARDOWN="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'teardown.sh')),
                 'mkdir -p $CANINE_JOB_INPUTS',
                 'mkdir -p $CANINE_JOB_ROOT',
+                'chmod 755 $CANINE_JOB_LOCALIZATION',
             ] + exports
         ) + '\ncd $CANINE_JOB_ROOT\n'
 


### PR DESCRIPTION
1. Closes #57 by running `chmod` on the mount point before cleanup
2. Closes #60 by adding `chmod` to setup.sh to make sure the execute bit is set on localization.sh