### PR TITLE
Fix read-only disk mount bugs

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -695,7 +695,7 @@ class AbstractLocalizer(abc.ABC):
 
                   # symlink into the canine directory
                   # note it might already exist if we are retrying this task
-                  "if [[ ! -L ${{CANINE_LOCAL_DISK_DIR}}/{file} ]]; then ln -s ${{CANINE_LOCAL_DISK_DIR}}/{file} {path}; fi".format(file = file, path = dest.remotepath),
+                  "if [[ ! -L {path} ]]; then ln -s ${{CANINE_LOCAL_DISK_DIR}}/{file} {path}; fi".format(file = file, path = dest.remotepath),
                 ]
                 docker_args.append('-v $CANINE_LOCAL_DISK_DIR:$CANINE_LOCAL_DISK_DIR')
                 exports.append('export {}="{}"'.format(


### PR DESCRIPTION
* Force a zero exit for mounting disk, to avoid race conditions
* Explicitly check existence of mountpoint, since we can no longer depend on the exit code
* Check if symlink to file on RO disk already exists before attempting to create