### PR TITLE
Allow external logging

### DIFF
--- a/canine/backends/base.py
+++ b/canine/backends/base.py
@@ -8,7 +8,7 @@ import stat
 import sys
 from contextlib import ExitStack
 from uuid import uuid4 as uuid
-from ..utils import ArgumentHelper, check_call
+from ..utils import ArgumentHelper, check_call, canine_logging
 import pandas as pd
 
 SLURM_PARTITION_RECON = b'slurm_load_partitions: Unable to contact slurm controller (connect failure)'
@@ -468,7 +468,7 @@ class AbstractSlurmBackend(abc.ABC):
         status, stdout, stderr = self.invoke("sinfo")
         n_iter = 0
         while status != 0 and SLURM_PARTITION_RECON in stderr.read():
-            print("Slurm controller not ready. Retrying in 10s...", file=sys.stderr)
+            canine_logging.print("Slurm controller not ready. Retrying in 10s...", file=sys.stderr)
             time.sleep(10)
             status, stdout, stderr = self.invoke("sinfo")
             n_iter += 1

--- a/canine/backends/base.py
+++ b/canine/backends/base.py
@@ -468,7 +468,7 @@ class AbstractSlurmBackend(abc.ABC):
         status, stdout, stderr = self.invoke("sinfo")
         n_iter = 0
         while status != 0 and SLURM_PARTITION_RECON in stderr.read():
-            canine_logging.print("Slurm controller not ready. Retrying in 10s...", file=sys.stderr)
+            canine_logging.warning("Slurm controller not ready. Retrying in 10s...")
             time.sleep(10)
             status, stdout, stderr = self.invoke("sinfo")
             n_iter += 1

--- a/canine/backends/dockerTransient.py
+++ b/canine/backends/dockerTransient.py
@@ -15,7 +15,7 @@ import threading
 import time
 
 from .imageTransient import TransientImageSlurmBackend, list_instances, gce
-from ..utils import get_default_gcp_project, gcp_hourly_cost, isatty
+from ..utils import get_default_gcp_project, gcp_hourly_cost, isatty, canine_logging
 
 from requests.exceptions import ConnectionError as RConnectionError
 from urllib3.exceptions import ProtocolError
@@ -126,12 +126,12 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
         try:
             ready_for_docker()
         except:
-            print("Docker host is not ready to start container!")
+            canine_logging.error("Docker host is not ready to start container!")
             raise
 
         #
         # create the Slurm container if it's not already present
-        print("Starting Slurm controller ...")
+        canine_logging.info("Starting Slurm controller ...")
         if self.config["cluster_name"] not in [x.name for x in self.dkr.containers.list()]:
             # FIXME: gcloud is cloud-provider specific. how can we make this more generic?
             gcloud_conf_dir = subprocess.check_output("echo -n ~/.config/gcloud", shell = True).decode()
@@ -217,8 +217,8 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
               timeout = 10
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            print("Couldn't delete node configuration file:", file = sys.stderr)
-            print(e)
+            canine_logging.error("Couldn't delete node configuration file:")
+            canine_logging.error(e)
 
         #
         # shutdown nodes that are still running (except NFS)
@@ -258,7 +258,7 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
             try:
                 subprocess.check_call("sudo umount -f /mnt/nfs", shell = True)
             except subprocess.CalledProcessError:
-                print("Could not unmount NFS (do you have open files on it?)\nPlease run `lsof | grep /mnt/nfs`, close any open files, and run `sudo umount -f /mnt/nfs` before attempting to run another pipeline.")
+                canine_logging.error("Could not unmount NFS (do you have open files on it?)\nPlease run `lsof | grep /mnt/nfs`, close any open files, and run `sudo umount -f /mnt/nfs` before attempting to run another pipeline.")
 
         # superclass method will stop/delete/leave the NFS running, depending on
         # how self.config["nfs_action_on_stop"] is set.
@@ -285,7 +285,7 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
         # TODO: use API for this
         nfs_inst = instances.loc[instances["name"] == nfs_nodename].squeeze()
         if nfs_inst.empty:
-            print("Creating NFS server " + nfs_nodename)
+            canine_logging.info("Creating NFS server " + nfs_nodename)
             subprocess.check_call(
                 """gcloud compute instances create {nfs_nodename} \
                    --image {image} --machine-type n1-standard-4 --zone {compute_zone} \
@@ -297,7 +297,7 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
 
         # otherwise, check that NFS is a valid node, and if so, start if necessary
         else:
-            print("Found preexisting NFS server " + nfs_nodename)
+            canine_logging.info("Found preexisting NFS server " + nfs_nodename)
 
             # make sure NFS was created by Canine
             if "caninetransientimage" not in nfs_inst["tags"]:
@@ -316,13 +316,13 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
             # if we passed these checks, start the NFS if necessary
             # TODO: use the API for this
             if nfs_inst["status"] == "TERMINATED":
-                print("Starting preexisting NFS server ... ", end = "", flush = True)
+                canine_logging.print("Starting preexisting NFS server ... ", end = "", flush = True)
                 subprocess.check_call(
                     """gcloud compute instances start {ni} --zone {z} \
                     """.format(ni = nfs_nodename, z = nfs_inst["zone"]),
                     shell = True
                 )
-                print("done", flush = True)
+                canine_logging.print("done", flush = True)
 
         # start NFS monitoring thread
         self.NFS_monitor_lock = threading.Event()
@@ -380,12 +380,12 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
                 if inst_details["status"] != "RUNNING":
                     self._pzw(gce.instances().start)(instance = nodename).execute()
             except:
-                print("Error querying NFS server status; retrying in 60s ...", file = sys.stderr)
+                canine_logging.warning("Error querying NFS server status; retrying in 60s ...")
 
             time.sleep(60)
 
     def wait_for_container_to_be_ready(self, timeout = 3000):
-        print("Waiting up to {} seconds for Slurm controller to start ...".format(timeout))
+        canine_logging.info("Waiting up to {} seconds for Slurm controller to start ...".format(timeout))
         (rc, _, _) = self.invoke(
           "timeout {} bash -c 'while [ ! -f /.started ]; do sleep 1; done'".format(timeout),
           interactive = True

--- a/canine/backends/gcpTransient.py
+++ b/canine/backends/gcpTransient.py
@@ -8,7 +8,7 @@ import os
 import sys
 import warnings
 from .remote import RemoteSlurmBackend
-from ..utils import get_default_gcp_zone, get_default_gcp_project, ArgumentHelper, check_call, gcp_hourly_cost
+from ..utils import get_default_gcp_zone, get_default_gcp_project, ArgumentHelper, check_call, gcp_hourly_cost, canine_logging
 # import paramiko
 import yaml
 import pandas as pd
@@ -219,13 +219,13 @@ class TransientGCPSlurmBackend(RemoteSlurmBackend):
             self.load_config_args()
             time.sleep(30) # Key propagation time
             super().__enter__()
-            print("Waiting for slurm to initialize")
+            canine_logging.info("Waiting for slurm to initialize")
             rc, sout, serr = self.invoke("which sinfo")
             while rc != 0:
                 time.sleep(10)
                 rc, sout, serr = self.invoke("which sinfo")
             time.sleep(60)
-            print("Slurm controller is ready. Please call .wait_for_cluster_ready() to wait until the slurm compute nodes are ready to accept work")
+            canine_logging.info("Slurm controller is ready. Please call .wait_for_cluster_ready() to wait until the slurm compute nodes are ready to accept work")
             return self
         except:
             self.stop()

--- a/canine/backends/imageTransient.py
+++ b/canine/backends/imageTransient.py
@@ -157,7 +157,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
 
             self.stop()
         except Exception as e:
-            canine_logging.error("ERROR: Could not initialize cluster; attempting to tear down.")
+            canine_logging.error("Could not initialize cluster; attempting to tear down.")
 
             self.stop()
             raise e
@@ -215,7 +215,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
             ex_nodes = nodenames.index[nodenames["is_ex_node"]]
 
             if not ex_nodes.empty:
-                canine_logging.warning("WARNING: the following nodes already exist outside of Canine and Canine will not touch these nodes: \n - {}".format("\n - ".join(ex_nodes)))
+                canine_logging.warning("The following nodes already exist outside of Canine and Canine will not touch these nodes: \n - {}".format("\n - ".join(ex_nodes)))
 
             # ERROR if any instance types (Canine or external) are incongruous
             # with given definition
@@ -223,7 +223,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                                (instances.loc[:, "machineType"] != self.config["worker_type"])
 
             if typemismatch_idx.any():
-                canine_logging.error("ERROR: nodes that already exist do not match specified machine type ({worker_type}), which will result in Slurm bitmap corruption.".format(**self.config))
+                canine_logging.error("Nodes that already exist do not match specified machine type ({worker_type}), which will result in Slurm bitmap corruption.".format(**self.config))
                 canine_logging.error(instances.drop(columns = "selfLink").loc[typemismatch_idx].to_string(index = False))
 
                 raise RuntimeError('Preexisting cluster nodes do not match specified machine type for new nodes')
@@ -234,7 +234,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                                (instances.loc[:, "zone"] != self.config["compute_zone"])
 
             if zonemismatch_idx.any():
-                canine_logging.warning("WARNING: nodes that already exist do not match specified compute zone ({compute_zone}), which may result in degraded performance or egress charges.".format(**self.config))
+                canine_logging.warning("Nodes that already exist do not match specified compute zone ({compute_zone}), which may result in degraded performance or egress charges.".format(**self.config))
                 canine_logging.warning(instances.drop(columns = "selfLink").loc[zonemismatch_idx].to_string(index = False))
 
         self.nodes = nodenames.loc[~nodenames["is_ex_node"]]
@@ -282,7 +282,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
             try:
                 self._pzw(gce.instances().stop)(instance = node).execute()
             except Exception as e:
-                canine_logging.warning("WARNING: couldn't shutdown instance {}".format(node))
+                canine_logging.warning("Couldn't shutdown instance {}".format(node))
                 canine_logging.warning(e)
 
     def stop(self, action_on_stop = None, kill_straggling_jobs = True):
@@ -325,10 +325,10 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                     self._pzw(gce.instances().stop)(instance = node).execute()
             except googleapiclient.errors.HttpError as e:
                 if "status" in e.resp and e.resp["status"] != "404":
-                    canine_logging.error("WARNING: couldn't shutdown instance {}".format(node))
+                    canine_logging.error("Couldn't shutdown instance {}".format(node))
                     canine_logging.error(e)
             except Exception as e:
-                canine_logging.error("WARNING: couldn't shutdown instance {}".format(node))
+                canine_logging.error("Couldn't shutdown instance {}".format(node))
                 canine_logging.error(e)
 
     def list_instances_all_zones(self):

--- a/canine/backends/imageTransient.py
+++ b/canine/backends/imageTransient.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 from .local import LocalSlurmBackend
-from ..utils import get_default_gcp_zone, get_default_gcp_project, gcp_hourly_cost
+from ..utils import get_default_gcp_zone, get_default_gcp_project, gcp_hourly_cost, canine_logging
 
 import googleapiclient.discovery as gd
 import googleapiclient.errors
@@ -16,9 +16,8 @@ import pandas as pd
 try:
     gce = gd.build('compute', 'v1')
 except gd._auth.google.auth.exceptions.GoogleAuthError:
-    print(
-        "Unable to load gcloud credentials. Transient Backends may not be available",
-        file=sys.stderr
+    canine_logging.warning(
+        "Unable to load gcloud credentials. Transient Backends may not be available"
     )
     gce = None
 
@@ -154,11 +153,11 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
 
             return self
         except KeyboardInterrupt:
-            print("\nCancelling cluster startup ...", file = sys.stderr)
+            canine_logging.warning("\nCancelling cluster startup ...")
 
             self.stop()
         except Exception as e:
-            print("ERROR: Could not initialize cluster; attempting to tear down.", file = sys.stderr)
+            canine_logging.error("ERROR: Could not initialize cluster; attempting to tear down.")
 
             self.stop()
             raise e
@@ -170,7 +169,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
         #
         # check if Slurm is already running locally; start (with hard reset) if not
 
-        print("Checking for running Slurm controller ... ", end = "", flush = True)
+        canine_logging.print("Checking for running Slurm controller ... ", end = "", flush = True)
 
         subprocess.check_call(
             """sudo -E -u {user} bash -c 'pgrep slurmctld || slurmctld -c -f {slurm_conf_path} &&
@@ -184,12 +183,12 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
         subprocess.check_call("pgrep slurmctld && pgrep slurmdbd && pgrep munged", shell = True,
                               stdout = subprocess.DEVNULL)
 
-        print("done", flush = True)
+        canine_logging.print("done", flush = True)
 
     def init_nodes(self):
         #
         # create/start worker nodes
-        print("Checking for preexisting cluster nodes ... ", end = "", flush = True)
+        canine_logging.print("Checking for preexisting cluster nodes ... ", end = "", flush = True)
 
         nodenames = pd.DataFrame(index = [
                       self.config["worker_prefix"] + str(x) for x in
@@ -208,7 +207,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
         instances = instances.merge(nodenames, left_on = "name", right_index = True,
                       how = "right")
 
-        print("done", flush = True)
+        canine_logging.print("done", flush = True)
 
         # handle nodes that will not be created
         if (nodenames["is_ex_node"] | nodenames["is_k9_node"]).any():
@@ -216,10 +215,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
             ex_nodes = nodenames.index[nodenames["is_ex_node"]]
 
             if not ex_nodes.empty:
-                print("WARNING: the following nodes already exist outside of Canine:\n - ",
-                  file = sys.stderr, end = "")
-                print("\n - ".join(ex_nodes), file = sys.stderr)
-                print("Canine will not touch these nodes.")
+                canine_logging.warning("WARNING: the following nodes already exist outside of Canine and Canine will not touch these nodes: \n - {}".format("\n - ".join(ex_nodes)))
 
             # ERROR if any instance types (Canine or external) are incongruous
             # with given definition
@@ -227,10 +223,8 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                                (instances.loc[:, "machineType"] != self.config["worker_type"])
 
             if typemismatch_idx.any():
-                print("ERROR: nodes that already exist do not match specified machine type ({worker_type}):".format(**self.config), file = sys.stderr)
-                print(instances.drop(columns = "selfLink").loc[typemismatch_idx] \
-                  .to_string(index = False), file = sys.stderr)
-                print("This will result in Slurm bitmap corruption.", file = sys.stderr)
+                canine_logging.error("ERROR: nodes that already exist do not match specified machine type ({worker_type}), which will result in Slurm bitmap corruption.".format(**self.config))
+                canine_logging.error(instances.drop(columns = "selfLink").loc[typemismatch_idx].to_string(index = False))
 
                 raise RuntimeError('Preexisting cluster nodes do not match specified machine type for new nodes')
 
@@ -240,11 +234,8 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                                (instances.loc[:, "zone"] != self.config["compute_zone"])
 
             if zonemismatch_idx.any():
-                print("WARNING: nodes that already exist do not match specified compute zone ({compute_zone}):".format(**self.config), file = sys.stderr)
-                print(instances.drop(columns = "selfLink").loc[zonemismatch_idx] \
-                  .to_string(index = False), file = sys.stderr)
-                print("This may result in degraded performance or egress charges.",
-                  file = sys.stderr)
+                canine_logging.warning("WARNING: nodes that already exist do not match specified compute zone ({compute_zone}), which may result in degraded performance or egress charges.".format(**self.config))
+                canine_logging.warning(instances.drop(columns = "selfLink").loc[zonemismatch_idx].to_string(index = False))
 
         self.nodes = nodenames.loc[~nodenames["is_ex_node"]]
 
@@ -256,7 +247,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
         if (~self.nodes["is_k9_node"]).any():
             nodes_to_create = self.nodes.index[~self.nodes["is_k9_node"]].values
 
-            print("Creating {0:d} worker nodes ... ".format(nodes_to_create.shape[0]),
+            canine_logging.print("Creating {0:d} worker nodes ... ".format(nodes_to_create.shape[0]),
                   end = "", flush = True)
             subprocess.check_call(
                 """gcloud compute instances create {workers} \
@@ -266,7 +257,7 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                 """.format(**self.config, workers = " ".join(nodes_to_create)),
                 shell = True
             )
-            print("done", flush = True)
+            canine_logging.print("done", flush = True)
 
         # start nodes previously created by Canine
 
@@ -275,14 +266,14 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
 
         # TODO: use API to start these
         if instances_to_start.shape[0] > 0:
-            print("Starting {0:d} preexisting worker nodes ... ".format(instances_to_start.shape[0]),
+            canine_logging.print("Starting {0:d} preexisting worker nodes ... ".format(instances_to_start.shape[0]),
                   end = "", flush = True)
             subprocess.check_call(
                 """gcloud compute instances start {workers} --zone {compute_zone} \
                 """.format(**self.config, workers = " ".join(instances_to_start.values)),
                 shell = True
             )
-            print("done", flush = True)
+            canine_logging.print("done", flush = True)
 
         #
         # shut down nodes exceeding init_node_count
@@ -291,8 +282,8 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
             try:
                 self._pzw(gce.instances().stop)(instance = node).execute()
             except Exception as e:
-                print("WARNING: couldn't shutdown instance {}".format(node), file = sys.stderr)
-                print(e)
+                canine_logging.warning("WARNING: couldn't shutdown instance {}".format(node))
+                canine_logging.warning(e)
 
     def stop(self, action_on_stop = None, kill_straggling_jobs = True):
         """
@@ -308,17 +299,17 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                 self.scancel(jobID = "", user = self.config["user"])
 
                 # wait for jobs to finish
-                print("Terminating all jobs ... ", end = "", flush = True)
+                canine_logging.print("Terminating all jobs ... ", end = "", flush = True)
                 tot_time = 0
                 while True:
                     if self.squeue().empty or tot_time > 60:
                         break
                     tot_time += 1
                     time.sleep(1)
-                print("done")
+                canine_logging.print("done")
             except Exception as e:
-                print("Error terminating all jobs!", file = sys.stderr)
-                print(e, file = sys.stderr)
+                canine_logging.error("Error terminating all jobs!")
+                canine_logging.error(e)
 
         #
         # stop, delete, or leave running compute nodes
@@ -334,11 +325,11 @@ class TransientImageSlurmBackend(LocalSlurmBackend): # {{{
                     self._pzw(gce.instances().stop)(instance = node).execute()
             except googleapiclient.errors.HttpError as e:
                 if "status" in e.resp and e.resp["status"] != "404":
-                    print("WARNING: couldn't shutdown instance {}".format(node), file = sys.stderr)
-                    print(e)
+                    canine_logging.error("WARNING: couldn't shutdown instance {}".format(node))
+                    canine_logging.error(e)
             except Exception as e:
-                print("WARNING: couldn't shutdown instance {}".format(node), file = sys.stderr)
-                print(e)
+                canine_logging.error("WARNING: couldn't shutdown instance {}".format(node))
+                canine_logging.error(e)
 
     def list_instances_all_zones(self):
         """

--- a/canine/backends/remote.py
+++ b/canine/backends/remote.py
@@ -10,7 +10,7 @@ import traceback
 import shlex
 import atexit
 from .base import AbstractSlurmBackend, AbstractTransport
-from ..utils import ArgumentHelper, make_interactive, check_call, isatty
+from ..utils import ArgumentHelper, make_interactive, check_call, isatty, canine_logging
 from agutil import StdOutAdapter
 import pandas as pd
 import paramiko
@@ -284,7 +284,7 @@ class RemoteSlurmBackend(AbstractSlurmBackend):
             return self.client.exec_command(command, get_pty=pty)
         except paramiko.ssh_exception.SSHException as e:
             if e.args == ('Key-exchange timed out waiting for key negotiation',):
-                print("Rekey timeout. Restarting client. Open transports may be interrupted")
+                canine_logging.print("Rekey timeout. Restarting client. Open transports may be interrupted")
                 reinit = []
                 for t in self.__transports:
                     if t.session is not None:
@@ -333,7 +333,7 @@ class RemoteSlurmBackend(AbstractSlurmBackend):
             self.early_rekey()
             return raw_stdout.channel.recv_exit_status(), stdout, stderr
         except KeyboardInterrupt:
-            print("Warning: Command will continue running on remote server as Paramiko has no way to interrupt commands", file=sys.stderr)
+            canine_logging.warning("Warning: Command will continue running on remote server as Paramiko has no way to interrupt commands")
             raise
 
     def interactive_login(self) -> int:

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -697,7 +697,8 @@ class AbstractLocalizer(abc.ABC):
                   # note it might already exist if we are retrying this task
                   "if [[ ! -L {path} ]]; then ln -s ${{CANINE_LOCAL_DISK_DIR}}/{file} {path}; fi".format(file = file, path = dest.remotepath),
                 ]
-                docker_args.append('-v $CANINE_LOCAL_DISK_DIR:$CANINE_LOCAL_DISK_DIR')
+                # Removed, this is actually '-v :'
+                #docker_args.append('-v $CANINE_LOCAL_DISK_DIR:$CANINE_LOCAL_DISK_DIR')
                 exports.append('export {}="{}"'.format(
                     key,
                     dest.remotepath

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 from collections import namedtuple
 from contextlib import ExitStack, contextmanager
 from ..backends import AbstractSlurmBackend, AbstractTransport, LocalSlurmBackend
-from ..utils import get_default_gcp_project, check_call
+from ..utils import get_default_gcp_project, check_call, canine_logging
 from hound.client import _getblob_bucket
 from agutil import status_bar
 import pandas as pd
@@ -108,7 +108,7 @@ class AbstractLocalizer(abc.ABC):
                 text = serr.read()
                 self.requester_pays[bucket] = b'requester pays bucket but no user project provided' in text
             if rc == 1 and b'BucketNotFoundException: 404' in text:
-                print(text.decode(), file=sys.stderr)
+                canine_logging.error(text.decode())
                 raise subprocess.CalledProcessError(rc, command)
         return bucket in self.requester_pays and self.requester_pays[bucket]
 
@@ -226,7 +226,7 @@ class AbstractLocalizer(abc.ABC):
             }
             if len([blob for blob in blobs if blob == '/'.join(components[1:])]) == 0:
                 # This is a directory
-                print("Copying directory:", gs_obj)
+                canine_logging.print("Copying directory:", gs_obj)
                 return self.gs_dircp(src, os.path.dirname(dest), context)
         except:
             # If there is an exception, or the above condition is false
@@ -251,7 +251,7 @@ class AbstractLocalizer(abc.ABC):
         """
         if isinstance(self.backend, LocalSlurmBackend):
             if exist_okay:
-                print("exist_okay not supported by LocalSlurmBackend", file=sys.stderr)
+                canine_logging.warning("exist_okay not supported by LocalSlurmBackend")
             return shutil.copytree(src, dest)
         with self.transport_context(transport) as transport:
             if not os.path.isdir(src):
@@ -260,7 +260,7 @@ class AbstractLocalizer(abc.ABC):
                 raise ValueError("Destination already exists: "+dest)
             dest = transport.normpath(dest)
             if self.transfer_bucket is not None:
-                print("Transferring through bucket", self.transfer_bucket)
+                canine_logging.print("Transferring through bucket", self.transfer_bucket)
                 path = os.path.join(str(uuid4()), os.path.basename(dest))
                 self.gs_dircp(
                     src,
@@ -278,12 +278,12 @@ class AbstractLocalizer(abc.ABC):
                         transport=transport
                     )
                 except:
-                    print(
+                    canine_logging.print(
                         crayons.red("ERROR:", bold=True),
                         "Failed to download the data on the remote system."
                         "Your files are still saved in",
                         'gs://{}/{}'.format(self.transfer_bucket, path),
-                        file=sys.stderr
+                        file=sys.stderr, type = "error"
                     )
                     raise
                 cmd = "gsutil -m {} rm -r gs://{}/{}".format(
@@ -291,13 +291,13 @@ class AbstractLocalizer(abc.ABC):
                     self.transfer_bucket,
                     os.path.dirname(path),
                 )
-                print(cmd)
+                canine_logging.info(cmd)
                 subprocess.check_call(
                     cmd,
                     shell=True
                 )
             else:
-                print("Transferring directly over SFTP")
+                canine_logging.info("Transferring directly over SFTP")
                 transport.sendtree(src, dest)
 
     def receivetree(self, src: str, dest: str, transport: typing.Optional[AbstractTransport] = None, exist_okay=False):
@@ -307,7 +307,7 @@ class AbstractLocalizer(abc.ABC):
         """
         if isinstance(self.backend, LocalSlurmBackend):
             if exist_okay:
-                print("exist_okay not supported by LocalSlurmBackend", file=sys.stderr)
+                canine_logging.warning("exist_okay not supported by LocalSlurmBackend")
             return shutil.copytree(src, dest)
         with self.transport_context(transport) as transport:
             if not transport.isdir(src):
@@ -316,7 +316,7 @@ class AbstractLocalizer(abc.ABC):
                 raise ValueError("Destination already exists: "+dest)
             dest = os.path.abspath(dest)
             if self.transfer_bucket is not None:
-                print("Transferring through bucket", self.transfer_bucket)
+                canine_logging.print("Transferring through bucket", self.transfer_bucket)
                 path = os.path.join(str(uuid4()), os.path.basename(dest))
                 self.gs_dircp(
                     src,
@@ -334,12 +334,12 @@ class AbstractLocalizer(abc.ABC):
                         transport=transport
                     )
                 except:
-                    print(
+                    canine_logging.print(
                         crayons.red("ERROR:", bold=True),
                         "Failed to download the data on the local system."
                         "Your files are still saved in",
                         'gs://{}/{}'.format(self.transfer_bucket, path),
-                        file=sys.stderr
+                        file=sys.stderr, type="error"
                     )
                     raise
                 cmd = "gsutil -m {} rm -r gs://{}/{}".format(
@@ -347,13 +347,13 @@ class AbstractLocalizer(abc.ABC):
                     self.transfer_bucket,
                     os.path.dirname(path),
                 )
-                print(cmd)
+                canine_logging.info(cmd)
                 subprocess.check_call(
                     cmd,
                     shell=True
                 )
             else:
-                print("Transferring directly over SFTP")
+                canine_logging.info("Transferring directly over SFTP")
                 transport.receivetree(src, dest)
 
     def reserve_path(self, *args: typing.Any) -> PathType:
@@ -517,7 +517,7 @@ class AbstractLocalizer(abc.ABC):
                         else:
                             raise ValueError("Invalid override option [{}]".format(mode))
                     except OverrideValueError as e:
-                        print(e.args[0], file = sys.stderr)
+                        canine_logging.error(e.args[0])
                         self.inputs[jobId][arg] = Localization(
                             None,
                             self.reserve_path('jobs', jobId, 'inputs', os.path.basename(os.path.abspath(value)))
@@ -710,7 +710,9 @@ class AbstractLocalizer(abc.ABC):
                     shlex.quote(val.path.remotepath if isinstance(val.path, PathType) else val.path)
                 ))
             else:
-                print("Unknown localization command:", val.type, "skipping", key, val.path, file=sys.stderr)
+                canine_logging.print("Unknown localization command:", val.type, "skipping", key, val.path,
+                    file=sys.stderr, type="warning"
+                )
 
         # generate setup script
         setup_script = '\n'.join(

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -8,7 +8,7 @@ from subprocess import CalledProcessError
 from .adapters import AbstractAdapter, ManualAdapter, FirecloudAdapter
 from .backends import AbstractSlurmBackend, LocalSlurmBackend, RemoteSlurmBackend, DummySlurmBackend, TransientGCPSlurmBackend, TransientImageSlurmBackend, DockerTransientImageSlurmBackend, LocalDockerSlurmBackend
 from .localization import AbstractLocalizer, BatchedLocalizer, LocalLocalizer, RemoteLocalizer, NFSLocalizer
-from .utils import check_call, pandas_read_hdf5_buffered, pandas_write_hdf5_buffered
+from .utils import check_call, pandas_read_hdf5_buffered, pandas_write_hdf5_buffered, canine_logging
 import yaml
 import numpy as np
 import pandas as pd
@@ -211,13 +211,13 @@ class Orchestrator(object):
         elif len(self.job_spec) > 4000000:
             raise ValueError("Cannot exceed 4000000 jobs in one pipeline")
 
-        print("Preparing pipeline of", len(self.job_spec), "jobs")
-        print("Connecting to backend...")
+        canine_logging.print("Preparing pipeline of", len(self.job_spec), "jobs")
+        canine_logging.print("Connecting to backend...")
         if isinstance(self.backend, RemoteSlurmBackend):
             self.backend.load_config_args()
         start_time = time.monotonic()
         with self.backend:
-            print("Initializing pipeline workspace")
+            canine_logging.print("Initializing pipeline workspace")
             with self._localizer_type(self.backend, **self.localizer_args) as localizer:
                 #
                 # localize inputs
@@ -228,7 +228,7 @@ class Orchestrator(object):
                     localizer.clean_on_exit = False
                     return self.job_spec
 
-                print("Waiting for cluster to finish startup...")
+                canine_logging.print("Waiting for cluster to finish startup...")
                 self.backend.wait_for_cluster_ready()
 
                 # perform hard reset of cluster; some backends do this own their
@@ -237,22 +237,22 @@ class Orchestrator(object):
                 if self.backend.hard_reset_on_orch_init and self._slurmconf_path:
                     active_jobs = self.backend.squeue('all')
                     if len(active_jobs):
-                        print("There are active jobs. Skipping slurmctld restart")
+                        canine_logging.print("There are active jobs. Skipping slurmctld restart")
                     else:
                         try:
-                            print("Stopping slurmctld")
+                            canine_logging.print("Stopping slurmctld")
                             rc, stdout, stderr = self.backend.invoke(
                                 'sudo pkill slurmctld',
                                 True
                             )
                             check_call('sudo pkill slurmctld', rc, stdout, stderr)
-                            print("Loading configurations", self._slurmconf_path)
+                            canine_logging.print("Loading configurations", self._slurmconf_path)
                             rc, stdout, stderr = self.backend.invoke(
                                 'sudo slurmctld -c -f {}'.format(self._slurmconf_path),
                                 True
                             )
                             check_call('sudo slurmctld -c -f {}'.format(self._slurmconf_path), rc, stdout, stderr)
-                            print("Restarting slurmctl")
+                            canine_logging.print("Restarting slurmctl")
                             rc, stdout, stderr = self.backend.invoke(
                                 'sudo slurmctld reconfigure',
                                 True
@@ -260,13 +260,13 @@ class Orchestrator(object):
                             check_call('sudo slurmctld reconfigure', rc, stdout, stderr)
                         except CalledProcessError:
                             traceback.print_exc()
-                            print("Slurmctld restart failed")
+                            canine_logging.error("Slurmctld restart failed")
 
                 #
                 # submit job
-                print("Submitting batch job")
+                canine_logging.print("Submitting batch job")
                 batch_id = self.submit_batch_job(entrypoint_path, localizer.environment('remote'))
-                print("Batch id:", batch_id)
+                canine_logging.print("Batch id:", batch_id)
 
                 #
                 # wait for jobs to finish
@@ -277,24 +277,24 @@ class Orchestrator(object):
                 try:
                     completed_jobs, cpu_time, uptime, prev_acct = self.wait_for_jobs_to_finish(batch_id)
                 except:
-                    print("Encountered unhandled exception. Cancelling batch job", file=sys.stderr)
+                    canine_logging.error("Encountered unhandled exception. Cancelling batch job")
                     self.backend.scancel(batch_id)
                     localizer.clean_on_exit = False
                     raise
                 finally:
                     # Check if fully job-avoided so we still delocalize
                     if batch_id == -2 or len(completed_jobs):
-                        print("Delocalizing outputs")
+                        canine_logging.print("Delocalizing outputs")
                         outputs = localizer.delocalize(self.raw_outputs, output_dir)
 
-                print("Parsing output data")
+                canine_logging.print("Parsing output data")
                 self.adapter.parse_outputs(outputs)
 
                 df = self.make_output_DF(batch_id, outputs, cpu_time, prev_acct, localizer)
 
         try:
             runtime = time.monotonic() - start_time
-            print("Estimated total cluster cost:", self.backend.estimate_cost(
+            canine_logging.print("Estimated total cluster cost:", self.backend.estimate_cost(
                 runtime/3600,
                 node_uptime=sum(uptime.values())/120
             )[0])
@@ -306,14 +306,14 @@ class Orchestrator(object):
             return df
 
     def localize_inputs_and_script(self, localizer) -> str:
-        print("Localizing inputs...")
+        canine_logging.print("Localizing inputs...")
         abs_staging_dir = localizer.localize(
             self.job_spec,
             self.raw_outputs,
             self.localizer_overrides
         )
-        print("Job staged on SLURM controller in:", abs_staging_dir)
-        print("Preparing pipeline script")
+        canine_logging.print("Job staged on SLURM controller in:", abs_staging_dir)
+        canine_logging.print("Preparing pipeline script")
         env = localizer.environment('remote')
         root_dir = env['CANINE_ROOT']
         entrypoint_path = os.path.join(root_dir, 'entrypoint.sh')
@@ -405,9 +405,9 @@ class Orchestrator(object):
                 # dict with blanks
                 missing_outputs = self.job_spec.keys() - outputs.keys()
                 if missing_outputs:
-                    print("WARNING: {}/{} job(s) were catastrophically lost (no stdout/stderr available)".format(
+                    canine_logging.error("WARNING: {}/{} job(s) were catastrophically lost (no stdout/stderr available)".format(
                       len(missing_outputs), len(self.job_spec)
-                    ), file = sys.stderr)
+                    ))
                     outputs = { **outputs, **{ k : {} for k in missing_outputs } }
 
                 # make the output dataframe
@@ -441,7 +441,7 @@ class Orchestrator(object):
                     df["outputs"] = df["outputs"].agg({ **self.output_map, **identity_map })
             except:
                 df = pd.DataFrame()
-                print("Error generating output dataframe; see stack trace for details.", file = sys.stderr)
+                canine_logging.error("Error generating output dataframe; see stack trace for details.")
                 traceback.print_exc()
 
 
@@ -563,8 +563,8 @@ class Orchestrator(object):
 
                     return np.count_nonzero(~fail_idx)
                 except (ValueError, OSError) as e:
-                    print("Cannot recover preexisting task outputs: " + str(e), file = sys.stderr)
-                    print("Overwriting output and aborting job avoidance.", file = sys.stderr)
+                    canine_logging.warning("Cannot recover preexisting task outputs: " + str(e))
+                    canine_logging.warning("Overwriting output and aborting job avoidance.")
                     transport.rmtree(localizer.staging_dir)
                     transport.makedirs(localizer.staging_dir)
                     return 0

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -405,7 +405,7 @@ class Orchestrator(object):
                 # dict with blanks
                 missing_outputs = self.job_spec.keys() - outputs.keys()
                 if missing_outputs:
-                    canine_logging.error("WARNING: {}/{} job(s) were catastrophically lost (no stdout/stderr available)".format(
+                    canine_logging.error("{}/{} job(s) were catastrophically lost (no stdout/stderr available)".format(
                       len(missing_outputs), len(self.job_spec)
                     ))
                     outputs = { **outputs, **{ k : {} for k in missing_outputs } }

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -538,7 +538,10 @@ class Orchestrator(object):
                     js_df = js_df.sort_values(sort_cols.index.tolist())
 
                     if not r_df["inputs"].equals(js_df):
-                        raise ValueError("Cannot job avoid; values of input parameters do not match!")
+                        raise ValueError("Cannot job avoid; values of input parameters do not match!\n" + \
+                            "\u21B3saved:\n" + str(r_df["inputs"].to_dict()) + "\n" + \
+                            "\u21B3job:\n" + str(js_df.to_dict()) + "\n"
+                        )
 
                     # if all is well, figure out which jobs need to be re-run
                     fail_idx = r_df[("job", "slurm_state")] == "FAILED"

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -538,10 +538,7 @@ class Orchestrator(object):
                     js_df = js_df.sort_values(sort_cols.index.tolist())
 
                     if not r_df["inputs"].equals(js_df):
-                        raise ValueError("Cannot job avoid; values of input parameters do not match!\n" + \
-                            "\u21B3saved:\n" + str(r_df["inputs"].to_dict()) + "\n" + \
-                            "\u21B3job:\n" + str(js_df.to_dict()) + "\n"
-                        )
+                        raise ValueError("Cannot job avoid; values of input parameters do not match!")
 
                     # if all is well, figure out which jobs need to be re-run
                     fail_idx = r_df[("job", "slurm_state")] == "FAILED"


### PR DESCRIPTION
This PR replaces `print` with `canine_logging.print` and `canine_logging.info/warning/error`, which allows we redirect canine logs to prefect server. If `canine.set_get_logger_hook` is not invoked, it will still use `print` for logging.

In addition, https://github.com/getzlab/canine/commit/9418c2a828bf878c1905b6dfbad63a77e518df39 logs saved and new values when input parameters don't match in job avoidance, which makes it easier to debug job avoidance. An alternative solution that I prefer is to keep a backup of the saved dataframe instead of overwriting (probably with an option).