### PR TITLE
Revamp job avoidance and accounting

### DIFF
--- a/canine/backends/base.py
+++ b/canine/backends/base.py
@@ -346,9 +346,9 @@ class AbstractSlurmBackend(abc.ABC):
         df = pd.read_fwf(
             stdout,
             index_col=0
-        )
+        ).iloc[1:]
         df.index = df.index.map(str)
-        return df.loc[[idx for idx in df.index if not idx.startswith('---')]]
+        return df
 
     def sinfo(self, *slurmopts: str, **slurmparams: typing.Any) -> pd.DataFrame:
         """

--- a/canine/backends/base.py
+++ b/canine/backends/base.py
@@ -177,6 +177,13 @@ class AbstractTransport(abc.ABC):
         except FileNotFoundError:
             return False
 
+    @abc.abstractmethod
+    def glob(self, path: str) -> typing.List[str]:
+        """
+        Returns an array matching the glob pattern, or an empty list if no match.
+        """
+        pass
+
     def makedirs(self, path: str, exist_okay: bool = False):
         """
         Recursively build the requested directory structure

--- a/canine/backends/local.py
+++ b/canine/backends/local.py
@@ -1,4 +1,5 @@
 import typing
+import glob
 import os
 import io
 import sys
@@ -50,6 +51,9 @@ class LocalTransport(AbstractTransport):
         Returns stat information
         """
         return os.stat(path, follow_symlinks=follow_symlinks)
+
+    def glob(self, path: str) -> typing.List[str]:
+        return glob.glob(path)
 
     def chmod(self, path: str, mode: int):
         """

--- a/canine/backends/remote.py
+++ b/canine/backends/remote.py
@@ -111,6 +111,9 @@ class RemoteTransport(AbstractTransport):
             except KeyError as e:
                 raise FileNotFoundError(path) from e
 
+    def glob(self, path: str) -> typing.List[str]:
+        raise NotImplementedError("globbing not yet implemented for remote transport!")
+
     def chmod(self, path: str, mode: int):
         """
         Change file permissions

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -14,7 +14,6 @@ import re
 from uuid import uuid4
 from collections import namedtuple
 from contextlib import ExitStack, contextmanager
-from datetime import datetime
 from ..backends import AbstractSlurmBackend, AbstractTransport, LocalSlurmBackend
 from ..utils import get_default_gcp_project, check_call
 from hound.client import _getblob_bucket
@@ -44,10 +43,7 @@ class AbstractLocalizer(abc.ABC):
         self, backend: AbstractSlurmBackend, transfer_bucket: typing.Optional[str] = None,
         common: bool = True, staging_dir: str = None,
         project: typing.Optional[str] = None, temporary_disk_type: str = 'standard',
-        local_download_dir: typing.Optional[str] = None,
-        input_hash: typing.Optional[str] = None, script_hash: typing.Optional[str] = None,
-        hash_output_directory: bool = False,
-        **kwargs
+        local_download_dir: typing.Optional[str] = None, **kwargs
     ):
         """
         Initializes the Localizer using the given transport.
@@ -69,13 +65,6 @@ class AbstractLocalizer(abc.ABC):
         self.local_dir = self._local_dir.name
         # FIXME: This doesn't actually make sense. Unless we assume staging_dir == mount_path, then transport.normpath gives an inaccurate mount_path
         with self.backend.transport() as transport:
-            # add current date, script hash, and input hash to directory name, if requested
-            if staging_dir is not None and hash_output_directory:
-                date = datetime.now().strftime("%Y%m%d%H%M%S")
-                staging_dir += ":" + date
-                staging_dir += "_" + script_hash if script_hash is not None else ""
-                staging_dir += "_" + input_hash if input_hash is not None else ""
-
             self.staging_dir = transport.normpath(staging_dir if staging_dir is not None else str(uuid4()))
             # if transport.isdir(self.staging_dir) and not force:
             #     raise FileExistsError("{} already exists. Supply force=True to override".format(

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -423,6 +423,10 @@ class AbstractLocalizer(abc.ABC):
             self.common_inputs = set()
             seen = set()
             for jobId, values in inputs.items():
+                # noop; this shard was avoided
+                if values is None:
+                    continue
+
                 for arg, path in values.items():
                     if path in seen and (arg not in overrides or overrides[arg] == 'common'):
                         self.common_inputs.add(path)

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -377,7 +377,7 @@ class AbstractLocalizer(abc.ABC):
             if not transport.isfile(os.path.join(output_dir, '.canine_pipeline_manifest.tsv')):
                 script_path = self.backend.pack_batch_script(
                     'export CANINE_OUTPUTS={}'.format(output_dir),
-                    'cat <(echo "jobId\tfield\tpath") $CANINE_OUTPUTS/*/.canine_job_manifest > $CANINE_OUTPUTS/.canine_pipeline_manifest.tsv',
+                    'cat <(echo "jobId\tfield\tpattern\tpath") $CANINE_OUTPUTS/*/.canine_job_manifest > $CANINE_OUTPUTS/.canine_pipeline_manifest.tsv',
                     script_path=os.path.join(output_dir, 'manifest.sh')
                 )
                 check_call(

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -739,6 +739,7 @@ class AbstractLocalizer(abc.ABC):
             line.rstrip()
             for line in [
                 '#!/bin/bash',
+                'set -e',
                 'if [[ -d {0} ]]; then cd {0}; fi'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'workspace')),
                 # 'mv ../stderr ../stdout .',
                 'if which python3 2>/dev/null >/dev/null; then python3 {0} {1} {2} {3}; else python {0} {1} {2} {3}; fi'.format(

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -378,7 +378,6 @@ class AbstractLocalizer(abc.ABC):
                 script_path = self.backend.pack_batch_script(
                     'export CANINE_OUTPUTS={}'.format(output_dir),
                     'cat <(echo "jobId\tfield\tpath") $CANINE_OUTPUTS/*/.canine_job_manifest > $CANINE_OUTPUTS/.canine_pipeline_manifest.tsv',
-                    'rm -f $CANINE_OUTPUTS/*/.canine_job_manifest',
                     script_path=os.path.join(output_dir, 'manifest.sh')
                 )
                 check_call(

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -14,6 +14,7 @@ import re
 from uuid import uuid4
 from collections import namedtuple
 from contextlib import ExitStack, contextmanager
+from datetime import datetime
 from ..backends import AbstractSlurmBackend, AbstractTransport, LocalSlurmBackend
 from ..utils import get_default_gcp_project, check_call
 from hound.client import _getblob_bucket
@@ -43,7 +44,10 @@ class AbstractLocalizer(abc.ABC):
         self, backend: AbstractSlurmBackend, transfer_bucket: typing.Optional[str] = None,
         common: bool = True, staging_dir: str = None,
         project: typing.Optional[str] = None, temporary_disk_type: str = 'standard',
-        local_download_dir: typing.Optional[str] = None, **kwargs
+        local_download_dir: typing.Optional[str] = None,
+        input_hash: typing.Optional[str] = None, script_hash: typing.Optional[str] = None,
+        hash_output_directory: bool = False,
+        **kwargs
     ):
         """
         Initializes the Localizer using the given transport.
@@ -65,6 +69,13 @@ class AbstractLocalizer(abc.ABC):
         self.local_dir = self._local_dir.name
         # FIXME: This doesn't actually make sense. Unless we assume staging_dir == mount_path, then transport.normpath gives an inaccurate mount_path
         with self.backend.transport() as transport:
+            # add current date, script hash, and input hash to directory name, if requested
+            if staging_dir is not None and hash_output_directory:
+                date = datetime.now().strftime("%Y%m%d%H%M%S")
+                staging_dir += ":" + date
+                staging_dir += "_" + script_hash if script_hash is not None else ""
+                staging_dir += "_" + input_hash if input_hash is not None else ""
+
             self.staging_dir = transport.normpath(staging_dir if staging_dir is not None else str(uuid4()))
             # if transport.isdir(self.staging_dir) and not force:
             #     raise FileExistsError("{} already exists. Supply force=True to override".format(

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -32,11 +32,15 @@ def main(output_dir, jobId, patterns, copy):
         os.makedirs(jobdir)
     with open(os.path.join(jobdir, '.canine_job_manifest'), 'w') as manifest:
         for name, pattern in patterns:
+            n_matched = 0
             for target in glob.iglob(pattern):
+                # construct output file path
                 if name in {'stdout', 'stderr'}:
                     dest = os.path.join(jobdir, name)
                 else:
                     dest = os.path.join(jobdir, name, os.path.relpath(target))
+
+                # populate output directory
                 if not os.path.exists(dest):
                     if not os.path.isdir(os.path.dirname(dest)):
                         os.makedirs(os.path.dirname(dest))
@@ -70,6 +74,18 @@ def main(output_dir, jobId, patterns, copy):
                     name,
                     pattern,
                     os.path.relpath(dest.strip(), output_dir)
+                ))
+
+                n_matched += 1
+
+            # warn if no files matched; make log in manifest
+            if n_matched == 0:
+                print('WARNING: output name "{0}" (pattern "{1}") not found.'.format(name,  pattern), file = sys.stderr)
+                manifest.write("{}\t{}\t{}\t{}\n".format(
+                    jobId,
+                    name,
+                    pattern,
+                    "//not_found"
                 ))
 
 if __name__ == '__main__':

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -65,9 +65,10 @@ def main(output_dir, jobId, patterns, copy):
                         print("Error computing checksum for {}!".format(target), file = sys.stderr)
 
                 # write job manifest
-                manifest.write("{}\t{}\t{}\n".format(
+                manifest.write("{}\t{}\t{}\t{}\n".format(
                     jobId,
                     name,
+                    pattern,
                     os.path.relpath(dest.strip(), output_dir)
                 ))
 

--- a/canine/localization/local.py
+++ b/canine/localization/local.py
@@ -96,6 +96,10 @@ class BatchedLocalizer(AbstractLocalizer):
             else:
                 common_dests = {}
             for jobId, data in inputs.items():
+                # noop; this shard has been avoided
+                if data is None:
+                    continue
+
                 os.makedirs(os.path.join(
                     self.environment('local')['CANINE_JOBS'],
                     jobId,

--- a/canine/localization/nfs.py
+++ b/canine/localization/nfs.py
@@ -116,6 +116,10 @@ class NFSLocalizer(BatchedLocalizer):
         #      single input. It would make more sense to do this before the adapter
         #      converts raw inputs.
         for input_dict in inputs.values():
+            # noop; this shard was avoided
+            if input_dict is None:
+                continue
+
             for k, v in input_dict.items():
                 if k not in overrides:
                     if re.match(r"^/", v) is not None and self.same_volume(v) and \
@@ -133,6 +137,10 @@ class NFSLocalizer(BatchedLocalizer):
             else:
                 common_dests = {}
             for jobId, data in inputs.items():
+                # noop; this shard has been avoided
+                if data is None:
+                    continue
+
                 os.makedirs(os.path.join(
                     self.environment('local')['CANINE_JOBS'],
                     jobId,

--- a/canine/localization/remote.py
+++ b/canine/localization/remote.py
@@ -72,6 +72,10 @@ class RemoteLocalizer(AbstractLocalizer):
             else:
                 common_dests = {}
             for jobId, data in inputs.items():
+                # noop; this shard has been avoided
+                if data is None:
+                    continue
+
                 transport.makedirs(
                     os.path.join(
                         self.environment('remote')['CANINE_JOBS'],

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -416,9 +416,11 @@ class Orchestrator(object):
             acct = self.backend.sacct(
               "D",
               job = batch_id,
-              format = "JobId,State,ExitCode,CPUTimeRAW,Submit"
+              format = "JobId,State,ExitCode,CPUTimeRAW,ResvCPURAW,Submit"
             ).astype({'CPUTimeRAW': int, "Submit" : np.datetime64})
             acct = acct.loc[~acct.index.str.endswith("batch")]
+            acct.loc[:, "CPUTimeRAW"] += acct.loc[:, "ResvCPURAW"].astype(int)
+            acct = acct.drop(columns = ["ResvCPURAW"])
             acct = acct.groupby(acct.index).apply(grouper)
 
             for jid in [*waiting_jobs]:

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.9.0'
+version = '0.10.0'
 
 ADAPTERS = {
     'Manual': ManualAdapter,

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -4,11 +4,12 @@ import time
 import sys
 import warnings
 import traceback
+import hashlib
 from subprocess import CalledProcessError
 from .adapters import AbstractAdapter, ManualAdapter, FirecloudAdapter
 from .backends import AbstractSlurmBackend, LocalSlurmBackend, RemoteSlurmBackend, DummySlurmBackend, TransientGCPSlurmBackend, TransientImageSlurmBackend, DockerTransientImageSlurmBackend, LocalDockerSlurmBackend
 from .localization import AbstractLocalizer, BatchedLocalizer, LocalLocalizer, RemoteLocalizer, NFSLocalizer
-from .utils import check_call, pandas_read_hdf5_buffered, pandas_write_hdf5_buffered
+from .utils import check_call, pandas_read_hdf5_buffered, pandas_write_hdf5_buffered, sha1_base32
 import yaml
 import numpy as np
 import pandas as pd
@@ -164,11 +165,25 @@ class Orchestrator(object):
         self.backend = BACKENDS[self._backend_type](**backend)
 
         #
+        # hashes for job avoidance
+        script_hash = sha1_base32(bytearray("".join(self.script), "utf-8"), 4)
+        #input_hash = sha1_base32(, 4)
+
+        #
         # localizer
         self.localizer_args = config['localization'] if 'localization' in config else {}
         if self.localizer_args['strategy'] not in LOCALIZERS:
             raise ValueError("Unknown localization strategy '{}'".format(self.localizer_args))
         self._localizer_type = LOCALIZERS[self.localizer_args['strategy']]
+
+        # input_hash and script_hash can be overridden by explicitly passing them to config["localization"]
+        self.localizer_args = {
+          "script_hash" : script_hash,
+          "input_hash" : "xxxxx",
+          "hash_output_directory" : True,
+          **self.localizer_args
+        }
+
         self.localizer_overrides = {}
         if 'overrides' in self.localizer_args:
             self.localizer_overrides = {**self.localizer_args['overrides']}

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -351,7 +351,7 @@ class Orchestrator(object):
 
     def wait_for_jobs_to_finish(self, batch_id):
         completed_jobs = []
-        preempted_cpu_time = {}
+        #preempted_cpu_time = {}
         uptime = {}
         prev_acct = None
 
@@ -365,13 +365,13 @@ class Orchestrator(object):
             acct = self.backend.sacct(job=batch_id, format="JobId,State,ExitCode,CPUTimeRAW").astype({'CPUTimeRAW': int})
             for jid in [*waiting_jobs]:
                 if jid in acct.index:
-                    # check if job has restarted since last update due to preemption;
-                    # if yes, accumulate the CPU time used in the last attempt
-                    if prev_acct is not None and jid in prev_acct.index and prev_acct['CPUTimeRAW'][jid] > acct['CPUTimeRAW'][jid]:
-                        if jid in preempted_cpu_time:
-                            preempted_cpu_time[jid] += prev_acct['CPUTimeRAW'][jid]
-                        else:
-                            preempted_cpu_time[jid] = prev_acct['CPUTimeRAW'][jid]
+#                    # check if job has restarted since last update due to preemption;
+#                    # if yes, accumulate the CPU time used in the last attempt
+#                    if prev_acct is not None and jid in prev_acct.index and prev_acct['CPUTimeRAW'][jid] > acct['CPUTimeRAW'][jid]:
+#                        if jid in preempted_cpu_time:
+#                            preempted_cpu_time[jid] += prev_acct['CPUTimeRAW'][jid]
+#                        else:
+#                            preempted_cpu_time[jid] = prev_acct['CPUTimeRAW'][jid]
 
                     # job has completed
                     if acct['State'][jid] not in {'RUNNING', 'PENDING', 'NODE_FAIL'}:
@@ -386,15 +386,16 @@ class Orchestrator(object):
                     uptime[node] += 1
                 else:
                     uptime[node] = 1
-
-            # store this iteration of sacct for next polling interval
-            if prev_acct is None:
-                prev_acct = acct
-            else:
-                prev_acct = pd.concat([
-                    acct,
-                    prev_acct.loc[[idx for idx in prev_acct.index if idx not in acct.index]]
-                ])
+#
+#            # store this iteration of sacct for next polling interval
+#            if prev_acct is None:
+#                prev_acct = acct
+#            else:
+#                prev_acct = pd.concat([
+#                    acct,
+#                    #prev_acct.loc[[idx for idx in prev_acct.index if idx not in acct.index]]
+#                    prev_acct.loc[~prev_acct.index.isin(acct.index)]
+#                ])
 
         return completed_jobs, preempted_cpu_time, uptime, prev_acct
 
@@ -403,7 +404,7 @@ class Orchestrator(object):
 
         if batch_id != -2:
             try:
-                acct = self.backend.sacct(job=batch_id)
+                acct = self.backend.sacct(job=batch_id, "D")
 
                 # we cannot assume that all outputs were properly delocalized, i.e.
                 # self.job_spec.keys() == outputs.keys()

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -419,6 +419,7 @@ class Orchestrator(object):
               format = "JobId%50,State,ExitCode,CPUTimeRAW,ResvCPURAW,Submit"
             ).astype({'CPUTimeRAW': int, "ResvCPURAW" : float, "Submit" : np.datetime64})
             acct = acct.loc[~acct.index.str.endswith("batch")]
+            acct.loc[acct["ResvCPURAW"].isna(), "ResvCPURAW"] = 0
             acct.loc[:, "CPUTimeRAW"] += acct.loc[:, "ResvCPURAW"].astype(int)
             acct = acct.drop(columns = ["ResvCPURAW"])
             acct = acct.groupby(acct.index).apply(grouper)

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -416,8 +416,8 @@ class Orchestrator(object):
             acct = self.backend.sacct(
               "D",
               job = batch_id,
-              format = "JobId,State,ExitCode,CPUTimeRAW,ResvCPURAW,Submit"
-            ).astype({'CPUTimeRAW': int, "Submit" : np.datetime64})
+              format = "JobId%50,State,ExitCode,CPUTimeRAW,ResvCPURAW,Submit"
+            ).astype({'CPUTimeRAW': int, "ResvCPURAW" : float, "Submit" : np.datetime64})
             acct = acct.loc[~acct.index.str.endswith("batch")]
             acct.loc[:, "CPUTimeRAW"] += acct.loc[:, "ResvCPURAW"].astype(int)
             acct = acct.drop(columns = ["ResvCPURAW"])

--- a/canine/utils.py
+++ b/canine/utils.py
@@ -12,8 +12,10 @@ import google.auth
 import paramiko
 import shutil
 import time
+import numpy as np
 import pandas as pd
 import requests
+import hashlib
 
 def isatty(*streams: typing.IO) -> bool:
     """
@@ -353,3 +355,21 @@ def pandas_read_hdf5_buffered(key: str, buf: io.BufferedReader) -> pd.DataFrame:
           driver_core_image = buf.read()
         ) as store:
             return store[key]
+
+def base32(buf: bytes):
+    """
+    Convert a byte array into a base32 encoded string
+    """
+    table = np.array(list("abcdefghijklmnopqrstuvwxyz012345"))
+
+    bits = np.unpackbits(np.frombuffer(buf, dtype = np.uint8))
+    bits = np.pad(bits, (0, 5 - (len(bits) % 5)), constant_values = 0).reshape(-1, 5)
+    return "".join(table[np.ravel(bits@2**np.c_[4:-1:-1])])
+
+def sha1_base32(buf: bytes, n: int = None):
+    """
+    Return a base32 representation of the first n bytes of SHA1(buf).
+    If n = None, the entire buffer will be encoded.
+    """
+
+    return base32(hashlib.sha1(buf).digest()[slice(0, n)])

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     install_requires = [
         'paramiko>=2.5.0',
         'pandas>=0.24.1',
+        'numpy>=1.18.0',
         'google-auth>=1.6.3',
         'PyYAML>=5.1',
         'agutil>=4.1.0',


### PR DESCRIPTION
* Avoidance
  * avoided shards are now implemented as Slurm noops, by starting the batch paused then cancelling any noop'd shards
  * `delocalization.py` computes SHA1 checksums for every output
  * `delocalization.py` saves output patterns to job manifest, so that `Orchestrator.job_avoid()` can match them
  * `Orchestrator.job_avoid()` totally revamped to read from individual shard manifests, rather than entire job dataframe
* Accounting 
  * We save accounting information for each shard to disk, and can reload it in the exact format returned by `Backend.sacct()`. This lets us keep track of accounting info across avoided jobs
  * Simplified accounting in `Orchestrator.wait_for_jobs_to_finish`

* Job exit, localization, and teardown exit codes are all saved to disk by `entrypoint.sh`

* Add hashing features to `utils.py`

* Docker backend can connect to preexisting controller container, in which case the backend won't attempt to stop the container after it exits

* Bump version to 0.10
