### PR TITLE
Simplify localization

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -437,7 +437,10 @@ class AbstractLocalizer(abc.ABC):
             for path in self.common_inputs:
                 if path.startswith('gs://') or os.path.exists(path):
                     common_dests[path] = self.reserve_path('common', os.path.basename(os.path.abspath(path)))
-                    self.localize_file(path, common_dests[path], transport=transport)
+                    try:
+                        self.localize_file(path, common_dests[path], transport=transport)
+                    except FileExistsError:
+                        pass
 #                else:
 #                    print("Could not handle common file", path, file=sys.stderr)
             return {key: value for key, value in common_dests.items()}

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -473,6 +473,8 @@ class AbstractLocalizer(abc.ABC):
                     # common override already handled
                     # No localization needed, already copied
                     self.inputs[jobId][arg] = Localization(None, common_dests[value])
+
+                # override type was explicitly specified; try to handle it
                 elif mode is not False:
                     try:
                         if mode == 'stream':
@@ -519,6 +521,11 @@ class AbstractLocalizer(abc.ABC):
 
                         else:
                             raise ValueError("Invalid override option [{}]".format(mode))
+
+                    # the user specified an invalid override (e.g. "stream" 
+                    # for something that's not a bucket path); fall back to
+                    # handling this input as a string literal
+                    # TODO: should raise a warning here
                     except OverrideValueError as e:
                         canine_logging.error(e.args[0])
                         self.inputs[jobId][arg] = Localization(
@@ -531,6 +538,7 @@ class AbstractLocalizer(abc.ABC):
                             transport=transport
                         )
 
+                # if override was not explicitly specified, autodetect the input type
                 else:
                     # if no overrides were given, see if we can immediately
                     # localize this file

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -672,12 +672,15 @@ class AbstractLocalizer(abc.ABC):
                 localization_tasks += [
                   "if [[ ! -d $CANINE_LOCAL_DISK_DIR ]]; then sudo mkdir -p $CANINE_LOCAL_DISK_DIR; fi",
 
+                  # create tempfile to hold diagnostic information
+                  "DIAG_FILE=$(mktemp)",
+
                   # attach the disk if it's not already
                   "if [[ ! -e /dev/disk/by-id/google-{} ]]; then".format(disk),
                   # we can run into a race condition here if other tasks are
                   # attempting to mount the same disk simultaneously, so we
                   # force a 0 exit
-                  "gcloud compute instances attach-disk $CANINE_NODE_NAME --zone $CANINE_NODE_ZONE --disk {disk_name} --device-name {disk_name} --mode ro || true".format(disk_name = disk),
+                  "gcloud compute instances attach-disk $CANINE_NODE_NAME --zone $CANINE_NODE_ZONE --disk {disk_name} --device-name {disk_name} --mode ro &>> $DIAG_FILE || true".format(disk_name = disk),
                   "fi",
 
                   # mount the disk if it's not already
@@ -685,16 +688,17 @@ class AbstractLocalizer(abc.ABC):
                   # force a zero exit
                   "if ! mountpoint -q $CANINE_LOCAL_DISK_DIR; then",
                   # within container
-                  "sudo mount -o noload,ro,defaults /dev/disk/by-id/google-{disk_name} $CANINE_LOCAL_DISK_DIR || true".format(disk_name = disk),
+                  "sudo mount -o noload,ro,defaults /dev/disk/by-id/google-{disk_name} $CANINE_LOCAL_DISK_DIR &>> $DIAG_FILE || true".format(disk_name = disk),
                   # on host (so that other dockers can access it)
                   "if [[ -f /.dockerenv ]]; then",
-                  "sudo nsenter -t 1 -m mount -o noload,ro,defaults /dev/disk/by-id/google-{disk_name} $CANINE_LOCAL_DISK_DIR || true".format(disk_name = disk),
+                  "sudo nsenter -t 1 -m mount -o noload,ro,defaults /dev/disk/by-id/google-{disk_name} $CANINE_LOCAL_DISK_DIR &>> $DIAG_FILE || true".format(disk_name = disk),
                   "fi",
                   "fi",
 
                   # because we forced zero exits for the previous commands,
                   # we need to verify that the mount actually exists
-                  "mountpoint -q $CANINE_LOCAL_DISK_DIR || { echo 'Read-only disk mount failed!'; exit 1; }",
+                  "mountpoint -q $CANINE_LOCAL_DISK_DIR || { echo 'Read-only disk mount failed!'; cat $DIAG_FILE; exit 1; }",
+                  # TODO: write error to stderr; this isn't working for some reason
 
                   # symlink into the canine directory
                   # note it might already exist if we are retrying this task


### PR DESCRIPTION
* Print diagnostics for RODISK mount failures: since we are intentionally suppressing nonzero exits and error messages (since these can commonly arise nonfatally), we need a way of reporting what went wrong if things actually do fail
* Greatly simplify `prepare_job_inputs()` in localization base class. Previous logic was convoluted; new code reads much better
* Raise explicit errors for files with the same name in the inputs directory. There is no elegant way to recover from this, so we just raise an informative error and exit.