### PR TITLE
Wait for RODISK to be attached

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -711,8 +711,8 @@ class AbstractLocalizer(abc.ABC):
                   # wait for device to attach
                   "tries=0",
                   "while [ ! -b /dev/disk/by-id/google-{disk_name} ]; do".format(disk_name = disk),
-                  '[ $tries -gt 12 ] && { echo "Timeout exceeded for disk to attach; perhaps the stderr of `gcloud compute instances attach disk` might contain insight:"; cat $DIAG_FILE; exit 1; }',
-                  "sleep 10; ((tries++))",
+                  '[ $tries -gt 12 ] && { echo "Timeout exceeded for disk to attach; perhaps the stderr of \`gcloud compute instances attach disk\` might contain insight:"; cat $DIAG_FILE; exit 1; } || :',
+                  "sleep 10; ((++tries))",
                   "done",
 
                   # mount within container

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -708,9 +708,16 @@ class AbstractLocalizer(abc.ABC):
                   # as before, we can run into a race condition here, so we again
                   # force a zero exit
                   "if ! mountpoint -q $CANINE_LOCAL_DISK_DIR; then",
-                  # within container
+                  # wait for device to attach
+                  "tries=0",
+                  "while [ ! -b /dev/disk/by-id/google-{disk_name} ]; do".format(disk_name = disk),
+                  '[ $tries -gt 12 ] && { echo "Timeout exceeded for disk to attach; perhaps the stderr of `gcloud compute instances attach disk` might contain insight:"; cat $DIAG_FILE; exit 1; } > /dev/stderr',
+                  "sleep 10; ((tries++))",
+                  "done",
+
+                  # mount within container
                   "sudo mount -o noload,ro,defaults /dev/disk/by-id/google-{disk_name} $CANINE_LOCAL_DISK_DIR &>> $DIAG_FILE || true".format(disk_name = disk),
-                  # on host (so that other dockers can access it)
+                  # mount on host (so that other dockers can access it)
                   "if [[ -f /.dockerenv ]]; then",
                   "sudo nsenter -t 1 -m mount -o noload,ro,defaults /dev/disk/by-id/google-{disk_name} $CANINE_LOCAL_DISK_DIR &>> $DIAG_FILE || true".format(disk_name = disk),
                   "fi",

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -718,8 +718,7 @@ class AbstractLocalizer(abc.ABC):
 
                   # because we forced zero exits for the previous commands,
                   # we need to verify that the mount actually exists
-                  "mountpoint -q $CANINE_LOCAL_DISK_DIR || { echo 'Read-only disk mount failed!'; cat $DIAG_FILE; exit 1; }",
-                  # TODO: write error to stderr; this isn't working for some reason
+                  "mountpoint -q $CANINE_LOCAL_DISK_DIR || { echo 'Read-only disk mount failed!'; cat $DIAG_FILE; exit 1; } > /dev/stderr",
 
                   # symlink into the canine directory
                   # note it might already exist if we are retrying this task

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -711,7 +711,7 @@ class AbstractLocalizer(abc.ABC):
                   # wait for device to attach
                   "tries=0",
                   "while [ ! -b /dev/disk/by-id/google-{disk_name} ]; do".format(disk_name = disk),
-                  '[ $tries -gt 12 ] && { echo "Timeout exceeded for disk to attach; perhaps the stderr of `gcloud compute instances attach disk` might contain insight:"; cat $DIAG_FILE; exit 1; } > /dev/stderr',
+                  '[ $tries -gt 12 ] && { echo "Timeout exceeded for disk to attach; perhaps the stderr of `gcloud compute instances attach disk` might contain insight:"; cat $DIAG_FILE; exit 1; }',
                   "sleep 10; ((tries++))",
                   "done",
 
@@ -725,7 +725,8 @@ class AbstractLocalizer(abc.ABC):
 
                   # because we forced zero exits for the previous commands,
                   # we need to verify that the mount actually exists
-                  "mountpoint -q $CANINE_LOCAL_DISK_DIR || { echo 'Read-only disk mount failed!'; cat $DIAG_FILE; exit 1; } > /dev/stderr",
+                  "mountpoint -q $CANINE_LOCAL_DISK_DIR || { echo 'Read-only disk mount failed!'; cat $DIAG_FILE; exit 1; }",
+                  # TODO: write error to stderr; this isn't working for some reason
 
                   # symlink into the canine directory
                   # note it might already exist if we are retrying this task


### PR DESCRIPTION
When attaching the same disk concurrently to many instances, there can be a lag between `gcloud compute instances attach-disk` and the block device actually appearing.

Here, we explicitly check for `/dev/disks/by-id/<disk name>` every 10 seconds up to 12 retries before proceeding with the mount.