### PR TITLE
Symlink canine common inputs to job specific inputs directory

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -769,6 +769,11 @@ class AbstractLocalizer(abc.ABC):
 
               "done",
             ]
+        
+        ## Symlink common inputs to job inputs
+        localization_tasks += [
+            'ls -d "$CANINE_COMMON"/* | xargs -L1 -I{} ln -s {} "$CANINE_JOB_INPUTS"/'
+        ]
 
         # generate setup script
         setup_script = '\n'.join(


### PR DESCRIPTION
This PR adds symlink of common inputs to job specific inputs directory. It is needed if the task assumes, say, bam and bam index, are under the same directory. Those files may take different localization strategies, e.g. bam file may be localized with "remote" or "rodisk" on the worker, while bam index may be localized on the controller.