### PR TITLE
Suppress 'ls' exit code in localization.sh

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -772,7 +772,7 @@ class AbstractLocalizer(abc.ABC):
         
         ## Symlink common inputs to job inputs
         localization_tasks += [
-            'ls -d "$CANINE_COMMON"/* | xargs -L1 -I{} ln -s {} "$CANINE_JOB_INPUTS"/'
+            '(ls -d "$CANINE_COMMON"/* 2>/dev/null || true) | xargs -L1 -I{} ln -s {} "$CANINE_JOB_INPUTS"/'
         ]
 
         # generate setup script

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -772,7 +772,7 @@ class AbstractLocalizer(abc.ABC):
         
         ## Symlink common inputs to job inputs
         localization_tasks += [
-            '(ls -d "$CANINE_COMMON"/* 2>/dev/null || true) | xargs -L1 -I{} ln -s {} "$CANINE_JOB_INPUTS"/'
+            'find "$CANINE_COMMON"/ -mindepth 1 -maxdepth 1 -exec ln -sf {} "$CANINE_JOB_INPUTS"/ \;'
         ]
 
         # generate setup script


### PR DESCRIPTION
Fix my bug in #84 . Forgot localization script has `set -e`.