### PR TITLE
Use CRC32C instead of SHA1 for hashing outputs

### DIFF
--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -27,18 +27,24 @@ def same_volume(a, b):
     )
     return len(set(vols.decode("utf-8").rstrip().split("\n"))) == 1
 
-def get_gsfile_crc32c(path):
-    """
-    From wolf.Task
-    """
-    cmd = 'echo "Computing CRC32C checksum for {0} ..." >&2; gsutil hash -c -h {0}'.format(shlex.quote(path))
-    output = subprocess.check_output(cmd, shell=True).decode()
-    output = output.rstrip().split("\n")
-    output = [o for o in output if re.search(r"^\tHash \(crc32c\):\t\t", o)]
-    assert len(output) == 1
-    output = output[0]
-    output = re.sub(r"^\tHash \(crc32c\):\t\t", "", output)
-    return output
+def compute_crc32c(direc):
+    p = subprocess.Popen(
+      # -mindepth 2 to avoid hashing stdout/stderr; ! -name ".*" to avoid hashing
+      # any preexisting crc32c files
+      'find {} -mindepth 2 ! -type d ! -name ".*" | xargs gsutil hash -ch'.format(direc),
+      shell = True,
+      stdout = subprocess.PIPE,
+      stderr = subprocess.PIPE,
+      text = True
+    )
+    out, err = p.communicate()
+
+    if p.returncode != 0:
+        print("Error computing checksums, see stderr for details:", file = sys.stderr, flush = True)
+        print(err, file = sys.stderr, flush = True)
+        return []
+    else:
+        return re.findall(r'Hashes \[hex\] for (.*):\n\tHash \(crc32c\):\t\t([A-F0-9]{8})\n', out)
 
 def main(output_dir, jobId, patterns, copy):
     jobdir = os.path.join(output_dir, str(jobId))
@@ -69,23 +75,6 @@ def main(output_dir, jobId, patterns, copy):
                     else:
                         shutil.copytree(target, dest)
 
-                # compute checksum
-                if name not in {'stdout', 'stderr'}:
-                    try:
-                        crc32 = get_gsfile_crc32c(target)
-                        with open(
-                          os.path.join(
-                            jobdir,
-                            name,
-                            os.path.dirname(os.path.relpath(target)),
-                            "." + os.path.basename(target) + ".crc32c"
-                          ),
-                          "w"
-                        ) as crc32_file:
-                            crc32_file.write(crc32 + "\n")
-                    except subprocess.CalledProcessError:
-                        print("Error computing checksum for {}!".format(target), file = sys.stderr)
-
                 # write job manifest
                 manifest.write("{}\t{}\t{}\t{}\n".format(
                     jobId,
@@ -105,6 +94,18 @@ def main(output_dir, jobId, patterns, copy):
                     pattern,
                     "//not_found"
                 ))
+            else:
+                print('INFO: matched output name "{0}" (pattern "{1}")'.format(name,  pattern), file = sys.stderr)
+
+    # compute checksums for all files
+    print('Computing CRC32C checksums ...', file = sys.stderr, flush = True, end = "")
+    for target, crc32c in compute_crc32c(jobdir):
+        with open(os.path.join(
+            os.path.dirname(target),
+            "." + os.path.basename(target) + ".crc32c"
+          ), "w") as crc32c_file:
+            crc32c_file.write(crc32c + "\n")
+    print(' done', file = sys.stderr, flush = True)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('canine-delocalizer')

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import argparse
 import glob
 import os
+import re
 import shutil
 import subprocess
 import shlex

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -31,7 +31,7 @@ def get_gsfile_crc32c(path):
     From wolf.Task
     """
     ## TODO: does not work for directories
-    cmd = 'gsutil hash -c -h {}'.format(shlex.quote(gspath))
+    cmd = 'gsutil hash -c -h {}'.format(shlex.quote(path))
     output = subprocess.check_output(cmd, shell=True).decode()
     output = output.rstrip().split("\n")
     output = [o for o in output if re.search(r"^\tHash \(crc32c\):\t\t", o)]

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -31,7 +31,6 @@ def get_gsfile_crc32c(path):
     """
     From wolf.Task
     """
-    ## TODO: does not work for directories
     cmd = 'echo "Computing CRC32C checksum for {0} ..." >&2; gsutil hash -c -h {0}'.format(shlex.quote(path))
     output = subprocess.check_output(cmd, shell=True).decode()
     output = output.rstrip().split("\n")

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -32,7 +32,7 @@ def get_gsfile_crc32c(path):
     From wolf.Task
     """
     ## TODO: does not work for directories
-    cmd = 'gsutil hash -c -h {}'.format(shlex.quote(path))
+    cmd = 'echo "Computing CRC32C checksum for {0} ..." >&2; gsutil hash -c -h {0}'.format(shlex.quote(path))
     output = subprocess.check_output(cmd, shell=True).decode()
     output = output.rstrip().split("\n")
     output = [o for o in output if re.search(r"^\tHash \(crc32c\):\t\t", o)]
@@ -130,4 +130,6 @@ if __name__ == '__main__':
         help="Copy outputs instead of symlinking"
     )
     args = parser.parse_args()
+    print("**** STARTING DELOCALIZATION STEPS ****", file = sys.stderr, flush = True)
     main(args.dest, args.jobId, args.pattern, args.copy)
+    print("**** DELOCALIZATION COMPLETE ****", file = sys.stderr, flush = True)

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -72,7 +72,7 @@ def main(output_dir, jobId, patterns, copy):
                 # compute checksum
                 if name not in {'stdout', 'stderr'}:
                     try:
-                        crc32 = get_gsfile_crc32(target)
+                        crc32 = get_gsfile_crc32c(target)
                         with open(
                           os.path.join(
                             jobdir,

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.10.4'
+version = '0.10.5'
 
 ADAPTERS = {
     'Manual': ManualAdapter,


### PR DESCRIPTION
This makes local file hashes consistent with `gs://` URL hashes. That way, the same file provided to a wolF task as a `gs://` URL or as an output from an upstream task will cause the task to job avoid equivalently.