### PR TITLE
Miscellaneous rare bug fixes

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -393,7 +393,9 @@ class AbstractLocalizer(abc.ABC):
         """
         Delocalizes output from all jobs
         """
-        self.build_manifest()
+        # this seems to be crashing pipelines; since we don't use it anywhere,
+        # let's disable it for now
+        #self.build_manifest()
         self.receivetree(
             self.environment('remote')['CANINE_OUTPUT'],
             output_dir,

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -44,7 +44,7 @@ def compute_crc32c(direc):
         print(err, file = sys.stderr, flush = True)
         return []
     else:
-        return re.findall(r'Hashes \[hex\] for (.*):\n\tHash \(crc32c\):\t\t([A-F0-9]{8})\n', out)
+        return re.findall(r'Hashes \[hex\] for (.*):\n\tHash \(crc32c\):\t\t([A-Fa-f0-9]{8})\n', out)
 
 def main(output_dir, jobId, patterns, copy):
     jobdir = os.path.join(output_dir, str(jobId))

--- a/canine/localization/nfs.py
+++ b/canine/localization/nfs.py
@@ -203,7 +203,9 @@ class NFSLocalizer(BatchedLocalizer):
         """
         if output_dir is not None:
             warnings.warn("output_dir has no bearing on NFSLocalizer. outputs are available in {}/outputs".format(self.local_dir))
-        self.build_manifest()
+        # this seems to be crashing pipelines; since we don't use it anywhere,
+        # let's disable it for now
+        #self.build_manifest()
         output_dir = os.path.join(self.local_dir, 'outputs')
         output_files = {}
         for jobId in os.listdir(output_dir):

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -683,6 +683,7 @@ class Orchestrator(object):
                 except (ValueError, OSError) as e:
                     canine_logging.warning("Cannot recover preexisting task outputs: " + str(e))
                     canine_logging.warning("Overwriting output and aborting job avoidance.")
+                    self.job_spec = old_job_spec
                     transport.rmtree(localizer.staging_dir)
                     transport.makedirs(localizer.staging_dir)
                     return 0, old_job_spec

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -477,11 +477,17 @@ class Orchestrator(object):
                                 acct.loc[[jid]].to_csv(w, sep = "\t", header = False, index = False)
 
             # track node uptime
-            for node in {node for node in self.backend.squeue(jobs=batch_id)['NODELIST(REASON)'] if not node.startswith('(')}:
-                if node in uptime:
-                    uptime[node] += 1
-                else:
-                    uptime[node] = 1
+            try:
+                for node in {node for node in self.backend.squeue(jobs=batch_id)['NODELIST(REASON)'] if not node.startswith('(')}:
+                    if node in uptime:
+                        uptime[node] += 1
+                    else:
+                        uptime[node] = 1
+            # squeue can fail here if the job completed by the time we call it,
+            # so we catch any errors.
+            # TODO: make something less heavy-handed; this may hide true failures
+            except CalledProcessError:
+                pass
 
         return completed_jobs, uptime, acct
 

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -172,14 +172,14 @@ class Orchestrator(object):
                     if acct[jid].empty:
                         acct[jid] = pd.DataFrame(placeholder_fields, index = [0])
 
-                    # if job_spec[j] is None, this indicates a noop (job was avoided)
-                    # override state to completed
-                    if v is None:
-                        acct[jid]["State"] = "COMPLETED"
-
                 # sacct never got written
                 else:
                     acct[jid] = pd.DataFrame(placeholder_fields, index = [0])
+
+                # if job_spec[j] is None, this indicates a noop (job was avoided)
+                # override state to completed, regardless of what got loaded from disk
+                if v is None:
+                    acct[jid]["State"] = "COMPLETED"
 
         return pd.concat(acct).droplevel(1).rename_axis("JobID")
 

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.10.5'
+version = '0.10.6'
 
 ADAPTERS = {
     'Manual': ManualAdapter,


### PR DESCRIPTION
* `load_acct_from_disk` overrides whatever job status got written if the job exit code was 0. When loading .sacct from disk, we check to see if the shard was avoided (based on `.*exit_code`, and `self.job_spec[job] = None`). If it was avoided, we override whatever status got loaded from disk to "COMPLETED", since wolF checks to see if all statuses == "COMPLETED" to infer whether the whole task finished successfully.
* Fix a crash in`wait_for_jobs_to_finish`. If the job has already finished, the `squeue` command probing its runtime will fail, which will raise an exception and crash the whole task.
* Fix a job avoidance bug: if `job_avoid` fails, it may not rollback any changes to `self.job_spec`. This is problematic, since failure totally wipes the output directory, but an updated `self.job_spec` could potentially indicate jobs should be avoided, which would cause an incomplete batch
to be submitted.
* Update Docker backend to catch known recoverable Docker errors in `backend.invoke()` and retry the command with exponential backoff.