### PR TITLE
Stringify type checks

### DIFF
--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.10.6'
+version = '0.10.7'
 
 ADAPTERS = {
     'Manual': ManualAdapter,


### PR DESCRIPTION
If `orchestrator.stringify()` detects newlines in any `str(obj)`, it will optionally infer that this is an unsupported type. This is hacky, but the most elegant way I could think of to infer that some object being stringified that should gracefully degrade to a list or dict (e.g. a Pandas index) is not doing so.