### PR TITLE
Fix job avoidance when .sacct file is missing

### DIFF
--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -155,7 +155,7 @@ class Orchestrator(object):
 
         jobs_dir = localizer.environment("local")["CANINE_JOBS"]
         acct = {}
-        placeholder_fields = { "State" : np.nan, "CPUTimeRAW" : -1, "n_preempted" : -1 }
+        placeholder_fields = { "State" : np.nan, "ExitCode": "-", "CPUTimeRAW" : -1, "Submit": "-", "n_preempted" : -1 }
 
         with localizer.transport_context() as tr:
             for j, v in job_spec.items():


### PR DESCRIPTION
Fill in default values of `ExitCode` and `Submit`, which are required by `make_output_DF`.

https://github.com/getzlab/canine/blob/ceb3e7486a0190b19f1c6f3e637c8ee67aff7ec2/canine/orchestrator.py#L544-L548