### PR TITLE
Make stderr steps clearer

### DIFF
--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -130,6 +130,4 @@ if __name__ == '__main__':
         help="Copy outputs instead of symlinking"
     )
     args = parser.parse_args()
-    print("**** STARTING DELOCALIZATION STEPS ****", file = sys.stderr, flush = True)
     main(args.dest, args.jobId, args.pattern, args.copy)
-    print("**** DELOCALIZATION COMPLETE ****", file = sys.stderr, flush = True)

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -81,7 +81,7 @@ if [ $LOCALIZER_JOB_RC -eq 0 ]; then
   done
   echo -n $CANINE_JOB_RC > ../.job_exit_code
 else
-  echo '!~~~ LOCALIZATION FAILURE! ~~~!' >&2
+  echo '!~~~ LOCALIZATION FAILURE! JOB CANNOT RUN! ~~~!' >&2
   echo -n "DNR" > ../.job_exit_code
   echo -n $LOCALIZER_JOB_RC > ../.localizer_exit_code
   CANINE_JOB_RC=$LOCALIZER_JOB_RC

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -87,7 +87,7 @@ else
   CANINE_JOB_RC=$LOCALIZER_JOB_RC
 fi
 echo '++++ STARTING JOB DELOCALIZATION ++++' >&2
-$CANINE_JOBS/$SLURM_ARRAY_TASK_ID/teardown.sh
+$CANINE_JOBS/$SLURM_ARRAY_TASK_ID/teardown.sh >&2
 DELOC_RC=$?
 [ $DELOC_RC == 0 ] && echo '++++ DELOCALIZATION COMPLETE ++++' >&2 || echo '!+++ DELOCALIZATION FAILURE +++!' >&2
 echo -n $DELOC_RC > ../.teardown_exit_code


### PR DESCRIPTION
Add some jazzy delimiters to indicate whether errors happen during localization, the job itself, or delocalization.