### PR TITLE
Remove trailing slashes from local paths

### DIFF
--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -136,7 +136,7 @@ class HandleGSURL(FileType):
         super().__init__(path, **kwargs)
 
         # remove any trailing slashes, in case path refers to a directory
-        self.path = path.strip("/")
+        self.path = path.rstrip("/")
 
         # check if this bucket is requester pays
         self.rp_string = ""
@@ -149,7 +149,7 @@ class HandleGSURL(FileType):
         self.is_dir = False
 
     def _get_size(self):
-        output = subprocess.check_output('gsutil {} du -s {}'.format(self.rp_string, shlex.quote(self.path.strip("/"))), shell=True).decode()
+        output = subprocess.check_output('gsutil {} du -s {}'.format(self.rp_string, shlex.quote(self.path.rstrip("/"))), shell=True).decode()
         return int(output.split()[0])
 
     def _get_hash(self):
@@ -238,7 +238,7 @@ class HandleAWSURL(FileType):
         super().__init__(path, **kwargs)
 
         # remove any trailing slashes, in case path refers to a directory
-        self.path = path.strip("/")
+        self.path = path.rstrip("/")
 
         # keys get passed via environment variable
         self.command_env = {}

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -447,6 +447,12 @@ class HandleGDCHTTPURLStream(HandleGDCHTTPURL):
 class HandleRegularFile(FileType):
     localization_mode = "local"
 
+    def __init__(self, path, **kwargs):
+        super().__init__(path, **kwargs)
+
+        # remove any trailing slashes, in case path refers to a directory
+        self.path = path.rstrip("/")
+
     def _get_size(self):
         return os.path.getsize(self.path)
 


### PR DESCRIPTION
Failure to do so causes directories to be improperly symlinked from rodisks