### PR TITLE
Add pass-through support for rodisk URLs

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -664,20 +664,24 @@ class AbstractLocalizer(abc.ABC):
             for k, v in file_paths_arrays.items(): 
                 n_suff = 0
                 for x in v:
-                    file_paths.append([k, n_suff, x.path, x.hash, x.size, not (isinstance(x, file_handlers.StringLiteral) or isinstance(x, file_handlers.HandleRODISKURL or x.localization_mode == "stream"))])
+                    file_paths.append([k, n_suff, x.path, x.hash, x.size, not (isinstance(x, file_handlers.StringLiteral) or isinstance(x, file_handlers.HandleRODISKURL or x.localization_mode == "stream")), isinstance(x, file_handlers.HandleRODISKURL)])
                     n_suff += 1
 
             ## Create dataframe of files' attributes
-            F = pd.DataFrame(file_paths, columns = ["input", "array_idx", "path", "hash", "size", "localize"])
+            F = pd.DataFrame(file_paths, columns = ["input", "array_idx", "path", "hash", "size", "localize", "rdpassthru"])
             F["file_basename"] = F["path"].apply(os.path.basename)
 
             ## if there are no files to localize, throw an error
-            if len(F) > 0 and ~(F["localize"].all()):
-                raise ValueError("You requested to localize files to disk, but no localizable inputs were given:\n{}\nInputs must be valid local paths or supported remote URLs.".format(",".join([f"{input} : \"{path}\"" for _, path, input in F[["path", "input"]].itertuples()])))
+            if len(F) > 0 and (~(F["localize"] | F["rdpassthru"])).all():
+                raise ValueError("You requested to localize files to disk, but no localizable inputs were given:\n{}\nInputs must be valid local paths or supported remote URLs.".format(", ".join([f"{input} : \"{path}\"" for _, path, input in F[["path", "input"]].itertuples()])))
 
             ## if some files cannot be localized, throw a warning
-            if (~F["localize"]).any():
-                canine_logging.warning("You requested to localize files to disk, but some inputs cannot be localized. Inputs must be valid local paths or supported remote URLs. The following inputs will be skipped:\n{}".format(",".join([f"{input} : \"{path}\"" for _, path, input in F.loc[~F["localize"], ["path", "input"]].itertuples()])))
+            if (~(F["localize"] | F["rdpassthru"])).any():
+                canine_logging.warning("You requested to localize files to disk, but some inputs cannot be localized. Inputs must be valid local paths or supported remote URLs. The following inputs will be skipped:\n{}".format(", ".join([f"{input} : \"{path}\"" for _, path, input in F.loc[~(F["localize"] | F["rdpassthru"]), ["path", "input"]].itertuples()])))
+
+            ## handle special case if we are only passing through rodisk URLs; this is like a dry run
+            if F["rdpassthru"].any() and not F["localize"].any():
+                return None, [], [], F.loc[F["rdpassthru"], :].groupby("input")["path"].apply(list).to_dict()
 
             ## Disk name is determined by input names, files' basenames, and hashes
             disk_name = "canine-" + \
@@ -699,6 +703,10 @@ class AbstractLocalizer(abc.ABC):
 
             ## Save RODISK paths for subsequent use by downstream tasks
             rodisk_paths = F.loc[F["localize"], :].groupby("input")["disk_path"].apply(list).to_dict()
+
+            # if we are passing through any rodisk paths, add them to the rodisk_paths dict
+            if F["rdpassthru"].any():
+                rodisk_paths = {**rodisk_paths, **F.loc[F["rdpassthru"], :].groupby("input")["path"].apply(list).to_dict()}
 
         #
         # otherwise, we create a blank disk with a given name (if specified),


### PR DESCRIPTION
When passing a `rodisk://` URL to persistent disk localization, it gets passed through. This allows sub-workflows that do their own localization to be added to parent workflows that also do localization.

Also, clean up some error handling during persistent disk creation.