### PR TITLE
Revamp delocalization hashing code

### DIFF
--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -83,10 +83,11 @@ def main(output_dir, jobId, patterns, copy, scratch):
                     if not os.path.isdir(os.path.dirname(dest)):
                         os.makedirs(os.path.dirname(dest))
                     # we've output to a scratch disk; create (broken) symlink to RODISK mount
-                    if scratch:
+                    if scratch and name not in copy:
                         os.symlink(os.path.abspath(target), dest)
                     # Same volume check catches outputs from outside the workspace
-                    elif copy or not same_volume(target, jobdir):
+                    elif name in copy or not same_volume(target, jobdir):
+                        print(f'INFO: copying (not symlinking) file \'{target}\' (name "{name}", pattern "{pattern}")', file = sys.stderr)
                         if os.path.isfile(target):
                             shutil.copyfile(os.path.abspath(target), dest)
                         else:
@@ -160,8 +161,9 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '-c', '--copy',
-        action='store_true',
-        help="Copy outputs instead of symlinking"
+        action='append',
+        help="Copy output <name> instead of symlinking",
+        default=[]
     )
     parser.add_argument(
         '-s', '--scratch',
@@ -169,4 +171,4 @@ if __name__ == '__main__':
         help="Outputs were written to a scratch disk; will create (broken) symlinks to the scratch diskmountpoint"
     )
     args = parser.parse_args()
-    main(args.dest, args.jobId, args.pattern, args.copy, args.scratch)
+    main(args.dest, args.jobId, args.pattern, set(args.copy), args.scratch)

--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import argparse
 import glob
+import google_crc32c
 import os
 import re
 import shutil
@@ -27,29 +28,45 @@ def same_volume(a, b):
     )
     return len(set(vols.decode("utf-8").rstrip().split("\n"))) == 1
 
-def compute_crc32c(direc):
-    p = subprocess.Popen(
-      # -mindepth 2 to avoid hashing stdout/stderr; ! -name ".*" to avoid hashing
-      # any preexisting crc32c files
-      'find {} -mindepth 2 ! -type d ! -name ".*" | xargs gsutil hash -ch'.format(direc),
-      shell = True,
-      stdout = subprocess.PIPE,
-      stderr = subprocess.PIPE,
-      text = True
-    )
-    out, err = p.communicate()
+def compute_crc32c(path):
+    """
+    Adapted from localization/file_handlers.py.
+    """
+    hash_alg = google_crc32c.Checksum()
+    buffer_size = 8 * 1024
 
-    if p.returncode != 0:
-        print("Error computing checksums, see stderr for details:", file = sys.stderr, flush = True)
-        print(err, file = sys.stderr, flush = True)
-        return []
+    if os.path.isdir(path):
+        files = glob.iglob(path + "/**", recursive = True)
     else:
-        return re.findall(r'Hashes \[hex\] for (.*):\n\tHash \(crc32c\):\t\t([A-Fa-f0-9]{8})\n', out)
+        files = [path]
+
+    for f in files:
+        if os.path.isdir(f):
+            continue
+
+        file_size_MiB = int(os.path.getsize(path)/1024**2)
+        print(f"Hashing file {f} ({file_size_MiB} MiB)", file = sys.stderr, flush = True)
+
+        ct = 0
+        with open(f, "rb") as fp:
+            while True:
+                # output message every 100 MiB
+                if ct > 0 and not ct % int(100*1024**2/buffer_size):
+                    print(f"Hashing file {f}; {int(buffer_size*ct/1024**2)}/{file_size_MiB} MiB completed", file = sys.stderr, flush = True)
+
+                data = fp.read(buffer_size)
+                if not data:
+                    break
+                hash_alg.update(data)
+                ct += 1
+
+    return hash_alg.hexdigest().decode().upper()
 
 def main(output_dir, jobId, patterns, copy, scratch):
     jobdir = os.path.join(output_dir, str(jobId))
     if not os.path.isdir(jobdir):
         os.makedirs(jobdir)
+    matched_files = []
     with open(os.path.join(jobdir, '.canine_job_manifest'), 'w') as manifest:
         for name, pattern in patterns:
             n_matched = 0
@@ -64,20 +81,20 @@ def main(output_dir, jobId, patterns, copy, scratch):
                 if not os.path.exists(dest):
                     if not os.path.isdir(os.path.dirname(dest)):
                         os.makedirs(os.path.dirname(dest))
-                    if os.path.isfile(target):
-                        # we've output to a scratch disk; create (broken) symlink to RODISK mount
-                        if scratch:
-                            os.symlink(os.path.abspath(target), dest)
-                        # Same volume check catches outputs from outside the workspace
-                        elif copy or not same_volume(target, jobdir):
+                    # we've output to a scratch disk; create (broken) symlink to RODISK mount
+                    if scratch:
+                        os.symlink(os.path.abspath(target), dest)
+                    # Same volume check catches outputs from outside the workspace
+                    elif copy or not same_volume(target, jobdir):
+                        if os.path.isfile(target):
                             shutil.copyfile(os.path.abspath(target), dest)
-                        # TODO: is st_dev check equivalent to same_volume?
-                        elif os.stat(target).st_dev == os.stat(os.path.dirname(dest)).st_dev:
-                            os.symlink(os.path.relpath(target, os.path.dirname(dest)), dest)
                         else:
-                            os.symlink(os.path.abspath(target), dest)
+                            shutil.copytree(target, dest)
+                    # TODO: is st_dev check equivalent to same_volume?
+                    elif os.stat(target).st_dev == os.stat(os.path.dirname(dest)).st_dev:
+                        os.symlink(os.path.relpath(target, os.path.dirname(dest)), dest)
                     else:
-                        shutil.copytree(target, dest)
+                        os.symlink(os.path.abspath(target), dest)
 
                 # write job manifest
                 manifest.write("{}\t{}\t{}\t{}\n".format(
@@ -86,6 +103,9 @@ def main(output_dir, jobId, patterns, copy, scratch):
                     pattern,
                     os.path.relpath(dest.strip(), output_dir)
                 ))
+
+                # append to array of files that will be hashed
+                matched_files.append([dest, target])
 
                 n_matched += 1
 
@@ -103,12 +123,16 @@ def main(output_dir, jobId, patterns, copy, scratch):
 
     # compute checksums for all files
     print('Computing CRC32C checksums ...', file = sys.stderr, flush = True, end = "")
-    for target, crc32c in compute_crc32c(jobdir):
+    for dest, f in matched_files:
+        # don't hash stdout/stderr
+        if f.startswith(".."):
+            continue
+        # compute hash for this file
         with open(os.path.join(
-            os.path.dirname(target),
-            "." + os.path.basename(target) + ".crc32c"
+            os.path.dirname(dest),
+            "." + os.path.basename(dest) + ".crc32c"
           ), "w") as crc32c_file:
-            crc32c_file.write(crc32c + "\n")
+            crc32c_file.write(compute_crc32c(f) + "\n")
     print(' done', file = sys.stderr, flush = True)
 
 if __name__ == '__main__':

--- a/canine/localization/nfs.py
+++ b/canine/localization/nfs.py
@@ -211,7 +211,7 @@ class NFSLocalizer(BatchedLocalizer):
                     # if we're using a scratch disk, outputs should be RODISK
                     # objects for downstream tasks to mount. read symlinks to
                     # RODISK URLs
-                    if self.use_scratch_disk:
+                    if self.use_scratch_disk and outputname not in self.files_to_copy_to_outputs:
                         output_files[jobId][outputname] = ["rodisk://" + re.match(r".*(canine-scratch.*)", os.readlink(x))[1] for x in output_files[jobId][outputname]]
                 elif outputname in {'stdout', 'stderr'} and os.path.isfile(dirpath):
                     output_files[jobId][outputname] = [dirpath]

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
         'docker>=4.1.0',
         'psutil>=5.6.7',
         'port-for>=0.4',
-        'tables>=3.6.1'
+        'tables>=3.6.1',
+        'google-crc32c>=1.5.0'
     ],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
* Use google-crc32 library for hashing, rather than calling out to gsutil
* Recursively hash directories and return single aggregate hash for all files
* Remove old weird behavior of copying (rather than symlinking) directories to the output folder