### PR TITLE
More improvements to disk handling

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -801,7 +801,7 @@ class AbstractLocalizer(abc.ABC):
             'DELAY=1',
             'while [ ! -b /dev/disk/by-id/google-${GCP_DISK_NAME} ]; do',
               ## if disk is not a scratch disk, check once again if it's being created by another instance
-              'if gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep -q \'^http\' && ! gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(labels)" | grep -q "scratch=yes"; then',
+              'if gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep \'^http\' | grep -qv "$CANINE_NODE_NAME" && ! gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(labels)" | grep -q "scratch=yes"; then',
                 'TRIES=0',
                 # wait until disk is marked "finished"
                 'while ! gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(labels)" | grep -q "finished=yes"; do',

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -993,7 +993,9 @@ class AbstractLocalizer(abc.ABC):
             # note that this does not apply to scratch disks that already exist;
             # these have a special disk creation script that cause the localizer to
             # exit early.
+            localization_disk_already_exists = False
             if len(disk_creation_script) == 0:
+                localization_disk_already_exists = True
                 for k, v_array in self.rodisk_paths[jobId].items():
                     # if this input had previously been localized in prepare_job_inputs,
                     # delete it
@@ -1307,7 +1309,7 @@ class AbstractLocalizer(abc.ABC):
           "#!/bin/bash",
           "set -e"
         ] + localization_tasks + 
-        (['gcloud compute disks add-labels "$GCP_DISK_NAME" --zone "$CANINE_NODE_ZONE" --labels finished=yes'] if self.localize_to_persistent_disk else [])
+        (['gcloud compute disks add-labels "$GCP_DISK_NAME" --zone "$CANINE_NODE_ZONE" --labels finished=yes'] if self.localize_to_persistent_disk and not localization_disk_already_exists else [])
         ) + "\nset +e\n"
 
         # generate teardown script

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -810,7 +810,7 @@ class AbstractLocalizer(abc.ABC):
                   '[ $TRIES -ge 10 ] && { echo "Exceeded timeout waiting for disk to become available" >&2; exit 1; } || :',
                   '((++TRIES))',
                 'done',
-                'exit 0 #DEBUG_OMIT' if not self.use_scratch_disk else "", # other instance has completed the disk; no need to do anything else in the localization script, unless we need to set up a scratch disk for job outputs.
+                'exit 15 #DEBUG_OMIT', # special exit code to cause rest of entrypoint.sh to be skipped
               'fi',
               # TODO: what if the task exited on the other
               #       instance without running the teardown script

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -810,7 +810,7 @@ class AbstractLocalizer(abc.ABC):
                   '[ $TRIES -ge 10 ] && { echo "Exceeded timeout waiting for disk to become available" >&2; exit 1; } || :',
                   '((++TRIES))',
                 'done',
-                'exit 15 #DEBUG_OMIT', # special exit code to cause rest of entrypoint.sh to be skipped
+                'exit 0 #DEBUG_OMIT' if not self.use_scratch_disk else "", # other instance has completed the disk; no need to do anything else in the localization script, unless we need to set up a scratch disk for job outputs.
               'fi',
               # TODO: what if the task exited on the other
               #       instance without running the teardown script


### PR DESCRIPTION
* When checking if the disk is already attached to an instance, make sure that it's a different instance than the one it's running on
* Mark a disk as finished immediately after the localization step runs, rather than waiting for the teardown script to complete
* Only run the disk tagging command if the disk was created anew