### PR TITLE
Add support for common VM/Docker images

### DIFF
--- a/canine/backends/dockerTransient.py
+++ b/canine/backends/dockerTransient.py
@@ -120,7 +120,7 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
               image = image.tags[0], detach = True, network_mode = "host",
               volumes = {
                 "/mnt/nfs" : { "bind" : "/mnt/nfs", "mode" : "rw" },
-                gcloud_conf_dir : { "bind" : "/etc/gcloud", "mode" : "rw" }
+                gcloud_conf_dir : { "bind" : "/mnt/nfs/clust_conf/gcloud", "mode" : "rw" }
                },
               name = self.config["cluster_name"], command = "/bin/bash",
               user = self.config["user"], stdin_open = True, remove = True,

--- a/canine/backends/dockerTransient.py
+++ b/canine/backends/dockerTransient.py
@@ -32,7 +32,7 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
     def __init__(
         self, cluster_name, *,
         action_on_stop = "delete",
-        image_family = "slurm-gcp-docker",
+        image_family = "slurm-gcp-docker-v1",
         image_project = "broad-getzlab-workflows",
         image = None,
         clust_frac = 1.0, user = os.environ["USER"], shutdown_on_exit = False, **kwargs
@@ -114,6 +114,8 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
         canine_logging.info1("Starting Slurm controller ...")
         if self.config["cluster_name"] not in [x.name for x in self.dkr.containers.list()]:
             # FIXME: gcloud is cloud-provider specific. how can we make this more generic?
+            #        we could use Docker compose within slurm_gcp_docker to automate
+            #        the container startup
             gcloud_conf_dir = subprocess.check_output("echo -n ~/.config/gcloud", shell = True).decode()
             uinfo = pwd.getpwnam(self.config["user"])
             self.dkr.containers.run(

--- a/canine/backends/dockerTransient.py
+++ b/canine/backends/dockerTransient.py
@@ -31,8 +31,6 @@ gce_lock = threading.Lock()
 class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
     def __init__(
         self, cluster_name, *,
-        startup_script = "/usr/local/share/slurm_gcp_docker/src/provision_worker_container_host.sh",
-        shutdown_script = "/usr/local/share/slurm_gcp_docker/src/shutdown_worker_container_host.sh",
         action_on_stop = "delete", image_family = None, image = None,
         clust_frac = 1.0, user = os.environ["USER"], shutdown_on_exit = False, **kwargs
     ):
@@ -43,13 +41,6 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
         if "image" not in kwargs:
             kwargs["image"] = image
 
-        # superclass constructor does something special with startup|shutdown_script so
-        # we need to pass it in
-        kwargs["startup_script"] = "{script} {worker_prefix}".format(
-          script = startup_script,
-          worker_prefix = socket.gethostname()
-        )
-        kwargs["shutdown_script"] = shutdown_script
         super().__init__(**{**kwargs, **{ "slurm_conf_path" : "" }})
 
         self.config = {

--- a/canine/backends/dockerTransient.py
+++ b/canine/backends/dockerTransient.py
@@ -306,7 +306,8 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
         local_invoke = super(TransientImageSlurmBackend, self).invoke
         if self.container is not None and self.container().status == "running":
             if not bypass_docker:
-                cmd = "docker exec {ti_flag} {container} {command}".format(
+                cmd = "docker exec --user {user} {ti_flag} {container} {command}".format(
+                  user = self.config["user"],
                   ti_flag = "-ti" if interactive else "",
                   container = self.config["cluster_name"],
                   command = command

--- a/canine/backends/dockerTransient.py
+++ b/canine/backends/dockerTransient.py
@@ -82,7 +82,7 @@ class DockerTransientImageSlurmBackend(TransientImageSlurmBackend): # {{{
         #
         # check if image exists
         try:
-            image = self.dkr.images.get('broadinstitute/slurm_gcp_docker:latest')
+            image = self.dkr.images.get('gcr.io/broad-getzlab-workflows/slurm_gcp_docker:latest')
         except docker.errors.ImageNotFound:
             raise Exception("You have not yet built or pulled the Slurm Docker image!")
         except RConnectionError as e:

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -1313,7 +1313,7 @@ class AbstractLocalizer(abc.ABC):
                 'export CANINE_JOB_SETUP="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'setup.sh')),
                 'export CANINE_JOB_LOCALIZATION="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'localization.sh')),
                 'export CANINE_JOB_TEARDOWN="{}"'.format(os.path.join(compute_env['CANINE_JOBS'], jobId, 'teardown.sh')),
-                'export CANINE_DOCKER_ARGS="{docker}"'.format(docker=' '.join(set(docker_args))),
+                'export CANINE_DOCKER_ARGS="{docker} $CANINE_DOCKER_ARGS"'.format(docker=' '.join(set(docker_args))),
                 'mkdir -p $CANINE_JOB_INPUTS',
                 'mkdir -p $CANINE_JOB_WORKSPACE',
                 'chmod 755 $CANINE_JOB_LOCALIZATION'

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.13.1'
+version = '0.13.2'
 
 ADAPTERS = {
     'Manual': ManualAdapter,

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.13.0'
+version = '0.13.1'
 
 ADAPTERS = {
     'Manual': ManualAdapter,

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.12.1'
+version = '0.13.0'
 
 ADAPTERS = {
     'Manual': ManualAdapter,

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.13.2'
+version = '0.13.3'
 
 ADAPTERS = {
     'Manual': ManualAdapter,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'PyYAML>=5.1',
         'agutil>=4.1.0',
         'hound>=0.2.0',
-        'firecloud-dalmatian>=0.0.17',
+        'firecloud-dalmatian @ git+https://github.com/getzlab/dalmatian@d39177e',
         'google-api-python-client>=1.7.11',
         'docker>=4.1.0',
         'psutil>=5.6.7',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'tables>=3.6.1',
         'google-crc32c>=1.5.0',
         'google-cloud-compute>=1.6.1',
-        'slurm_gcp_docker>=0.12',
+        'slurm_gcp_docker>=0.12 @ git+https://github.com/getzlab/slurm_gcp_docker@oneimage',
     ],
     python_requires = ">3.7",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
         'tables>=3.6.1',
         'google-crc32c>=1.5.0',
         'google-cloud-compute>=1.6.1',
-        'slurm_gcp_docker>=0.12 @ git+https://github.com/getzlab/slurm_gcp_docker@oneimage',
+        #'slurm_gcp_docker>=0.12',
+        'slurm_gcp_docker @ git+https://github.com/getzlab/slurm_gcp_docker@oneimage',
     ],
     python_requires = ">3.7",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'google-crc32c>=1.5.0',
         'google-cloud-compute>=1.6.1',
         #'slurm_gcp_docker>=0.12',
-        'slurm_gcp_docker @ git+https://github.com/getzlab/slurm_gcp_docker@oneimage',
+        'slurm_gcp_docker @ git+https://github.com/getzlab/slurm_gcp_docker@v0.13',
     ],
     python_requires = ">3.7",
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,6 @@
 from setuptools import setup
 import re
 import os
-import sys
-
-ver_info = sys.version_info
-if ver_info < (3,7,0):
-    raise RuntimeError("canine requires at least python 3.7")
 
 with open(os.path.join(os.path.dirname(__file__), 'canine', 'orchestrator.py')) as r:
     version = re.search(r'version = \'(\d+\.\d+\.\d+[-_a-zA-Z0-9]*)\'', r.read()).group(1)
@@ -62,7 +57,9 @@ setup(
         'tables>=3.6.1',
         'google-crc32c>=1.5.0',
         'google-cloud-compute>=1.6.1',
+        'slurm_gcp_docker>=0.12',
     ],
+    python_requires = ">3.7",
     classifiers = [
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
* Update VM image family/project to reference common `broad-getzlab-workflows`
* Copy gcloud credentials to NFS on cluster startup
* Pass VM UID/GID to controller Docker
* Update dependencies to automatically install slurm_gcp_docker