### PR TITLE
Disk fixes

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -868,7 +868,7 @@ class AbstractLocalizer(abc.ABC):
             'mkdir -p "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
             'fi',
             'if ! mountpoint -q "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"; then',
-            'sudo mount -o discard,defaults /dev/disk/by-id/google-"${GCP_DISK_NAME}" "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
+            'timeout 30 sudo mount -o discard,defaults /dev/disk/by-id/google-"${GCP_DISK_NAME}" "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
             'sudo chmod -R a+rwX "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
             'fi',
 
@@ -1087,7 +1087,7 @@ class AbstractLocalizer(abc.ABC):
                 'gcloud compute instances set-disk-auto-delete $CANINE_NODE_NAME --zone $CANINE_NODE_ZONE --disk {}'.format(disk_name),
                 'sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-{}'.format(device_name),
 
-                'sudo mount -o discard,defaults /dev/disk/by-id/google-{} $CANINE_LOCAL_DISK_DIR'.format(
+                'timeout 30 sudo mount -o discard,defaults /dev/disk/by-id/google-{} $CANINE_LOCAL_DISK_DIR'.format(
                     device_name,
                 ),
                 'sudo chmod -R a+rwX {}'.format(self.local_download_dir),
@@ -1289,7 +1289,7 @@ class AbstractLocalizer(abc.ABC):
               "done",
 
               # mount within Slurm worker container
-              "sudo mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || true",
+              "timeout 30 sudo mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || true",
 #              # mount on host (so that task dockers can access it)
 #              "if [[ -f /.dockerenv ]]; then",
 #              "sudo nsenter -t 1 -m mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || true",

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -818,7 +818,7 @@ class AbstractLocalizer(abc.ABC):
             'DELAY=1',
             'while [ ! -b /dev/disk/by-id/google-${GCP_DISK_NAME} ]; do',
               ## check if disk is being created by _another_ instance (grep -qv $CANINE_NODE_NAME)
-              'if gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep \'^http\' | grep -qv "$CANINE_NODE_NAME"; then',
+              'if gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep \'^http\' | grep -qv "$CANINE_NODE_NAME"\'$\'; then',
                 # if disk is a localization disk (i.e. not a scratch disk), wait approximately how long it would take to transfer files to it
                 'if ! gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(labels)" | grep -q "scratch=yes"; then',
                   'TRIES=0',
@@ -858,7 +858,7 @@ class AbstractLocalizer(abc.ABC):
               # this means that the node is bad
               'if [ $DELAY -gt 8 ]; then',
                 'gcloud compute instances attach-disk "$CANINE_NODE_NAME" --zone "$CANINE_NODE_ZONE" --disk "$GCP_DISK_NAME" --device-name "$GCP_DISK_NAME" || :',
-                'if gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep -q $CANINE_NODE_NAME && [ ! -b /dev/disk/by-id/google-${GCP_DISK_NAME} ]; then',
+                'if gcloud compute disks describe $GCP_DISK_NAME --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep \'^http\' | grep -q $CANINE_NODE_NAME\'$\' && [ ! -b /dev/disk/by-id/google-${GCP_DISK_NAME} ]; then',
                   'sudo touch /.fatal_disk_issue_sentinel',
                   'echo "Node cannot attach disk; node is likely bad. Tagging for deletion." >&2',
                   'exit 1',
@@ -1277,7 +1277,7 @@ class AbstractLocalizer(abc.ABC):
                 'if [ $tries -gt 12 ]; then',
                   # check if the disk has attached successfully, but doesn't appear in /dev
                   # this means the node is likely bad
-                  'if gcloud compute disks describe ${CANINE_RODISK} --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep -q $CANINE_NODE_NAME && [ ! -b /dev/disk/by-id/google-${CANINE_RODISK} ]; then',
+                  'if gcloud compute disks describe ${CANINE_RODISK} --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep \'^http\' | grep -q $CANINE_NODE_NAME\'$\' && [ ! -b /dev/disk/by-id/google-${CANINE_RODISK} ]; then',
                     'sudo touch /.fatal_disk_issue_sentinel',
                     'echo "Node cannot attach disk; node is likely bad. Tagging for deletion." >&2',
                     'exit 1',

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -876,7 +876,7 @@ class AbstractLocalizer(abc.ABC):
             'mkdir -p "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
             'fi',
             'if ! mountpoint -q "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"; then',
-            'sudo timeout 30 mount -o discard,defaults /dev/disk/by-id/google-"${GCP_DISK_NAME}" "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
+            'sudo timeout -k 30 30 mount -o discard,defaults /dev/disk/by-id/google-"${GCP_DISK_NAME}" "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
             'sudo chmod -R a+rwX "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
             'fi',
 
@@ -1088,7 +1088,7 @@ class AbstractLocalizer(abc.ABC):
                 'gcloud compute instances set-disk-auto-delete $CANINE_NODE_NAME --zone $CANINE_NODE_ZONE --disk {}'.format(disk_name),
                 'sudo mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-{}'.format(device_name),
 
-                'sudo timeout 30 mount -o discard,defaults /dev/disk/by-id/google-{} $CANINE_LOCAL_DISK_DIR'.format(
+                'sudo timeout -k 30 30 mount -o discard,defaults /dev/disk/by-id/google-{} $CANINE_LOCAL_DISK_DIR'.format(
                     device_name,
                 ),
                 'sudo chmod -R a+rwX {}'.format(self.local_download_dir),
@@ -1290,7 +1290,7 @@ class AbstractLocalizer(abc.ABC):
               "done",
 
               # mount within Slurm worker container
-              "sudo timeout 30 mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || true",
+              "sudo timeout -k 30 30 mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || true",
 #              # mount on host (so that task dockers can access it)
 #              "if [[ -f /.dockerenv ]]; then",
 #              "sudo nsenter -t 1 -m mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || true",

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -1362,10 +1362,8 @@ class AbstractLocalizer(abc.ABC):
                 'alias gcloud=gcloud_exp_backoff #DEBUG_OMIT',
                 'if [[ -d $CANINE_JOB_WORKSPACE ]]; then cd $CANINE_JOB_WORKSPACE; fi',
                 # 'mv ../stderr ../stdout .',
-                # do not run delocalization script if:
-                # * we're in debug mode
-                # * localization was skipped
-                'if [[ ( -z $CANINE_DEBUG_MODE && ! -z $LOCALIZER_JOB_RC && $LOCALIZER_JOB_RC != 15 ) || ( ! -d $CANINE_OUTPUT/$SLURM_ARRAY_TASK_ID ) ]]; then if which python3 2>/dev/null >/dev/null; then python3 {script_path} {output_root} {shard} {patterns} {copyflags} {scratchflag}; else python {script_path} {output_root} {shard} {patterns} {copyflags} {scratchflag}; fi; fi'.format(
+                # do not run delocalization script if we're in debug mode
+                'if [[ -z $CANINE_DEBUG_MODE ]]; then if which python3 2>/dev/null >/dev/null; then python3 {script_path} {output_root} {shard} {patterns} {copyflags} {scratchflag} {finishedflag}; else python {script_path} {output_root} {shard} {patterns} {copyflags} {scratchflag} {finishedflag}; fi; fi'.format(
                     script_path = os.path.join(compute_env['CANINE_ROOT'], 'delocalization.py'),
                     output_root = compute_env['CANINE_OUTPUT'],
                     shard = jobId,
@@ -1378,6 +1376,7 @@ class AbstractLocalizer(abc.ABC):
                         for name in self.files_to_copy_to_outputs 
                     ),
                     scratchflag = "--scratch" if self.use_scratch_disk else "",
+                    finishedflag = "--finished_scratch" if self.use_scratch_disk and scratch_disk_already_exists and self.scratch_disk_job_avoid else "",
                 ),
 
                 # remove stream dir

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -745,7 +745,7 @@ class AbstractLocalizer(abc.ABC):
             return None, [], [], rodisk_paths
 
         ## mount prefix
-        mount_prefix = "/mnt/nfs/rwdisks"
+        mount_prefix = "/mnt/rwdisks"
         disk_mountpoint = mount_prefix + "/" + disk_name
 
         ## Check if the disk already exists
@@ -873,11 +873,11 @@ class AbstractLocalizer(abc.ABC):
 
             ## mount
             'if [[ ! -d "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME" ]]; then',
-            'mkdir -p "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
+            'sudo mkdir -p "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
+            'sudo chown $(id -u):$(id -g) "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
             'fi',
             'if ! mountpoint -q "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"; then',
             'sudo timeout -k 30 30 mount -o discard,defaults /dev/disk/by-id/google-"${GCP_DISK_NAME}" "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
-            'sudo chmod -R a+rwX "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
             'fi',
 
             ## lock the disk
@@ -1166,7 +1166,7 @@ class AbstractLocalizer(abc.ABC):
                     disk = dgrp[1]
                     file = dgrp[2]
 
-                    disk_dir = "/mnt/nfs/rodisks/{}".format(disk)
+                    disk_dir = "/mnt/rodisks/{}".format(disk)
 
                     if disk not in canine_rodisks:
                         canine_rodisks.append(disk)
@@ -1254,7 +1254,10 @@ class AbstractLocalizer(abc.ABC):
               "CANINE_RODISK_DIR=CANINE_RODISK_DIR_${i}",
               "CANINE_RODISK_DIR=${!CANINE_RODISK_DIR}",
 
-              "if [[ ! -d ${CANINE_RODISK_DIR} ]]; then mkdir -p ${CANINE_RODISK_DIR}; fi",
+              "if [[ ! -d ${CANINE_RODISK_DIR} ]]; then",
+              "sudo mkdir -p ${CANINE_RODISK_DIR}",
+              "sudo chown $(id -u):$(id -g) ${CANINE_RODISK_DIR}",
+              "fi",
 
               # create tempfile to hold diagnostic information
               "DIAG_FILE=$(mktemp)",

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -874,10 +874,10 @@ class AbstractLocalizer(abc.ABC):
             ## mount
             'if [[ ! -d "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME" ]]; then',
             'sudo mkdir -p "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
-            'sudo chown $(id -u):$(id -g) "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
             'fi',
             'if ! mountpoint -q "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"; then',
             'sudo timeout -k 30 30 mount -o discard,defaults /dev/disk/by-id/google-"${GCP_DISK_NAME}" "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
+            'sudo chown $(id -u):$(id -g) "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
             'fi',
 
             ## lock the disk
@@ -1256,7 +1256,6 @@ class AbstractLocalizer(abc.ABC):
 
               "if [[ ! -d ${CANINE_RODISK_DIR} ]]; then",
               "sudo mkdir -p ${CANINE_RODISK_DIR}",
-              "sudo chown $(id -u):$(id -g) ${CANINE_RODISK_DIR}",
               "fi",
 
               # create tempfile to hold diagnostic information

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -1277,7 +1277,7 @@ class AbstractLocalizer(abc.ABC):
                 'if [ $tries -gt 12 ]; then',
                   # check if the disk has attached successfully, but doesn't appear in /dev
                   # this means the node is likely bad
-                  'if gcloud compute disks describe ${CANINE_RODISK} --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep \'^http\' | grep -q $CANINE_NODE_NAME\'$\' && [ ! -b /dev/disk/by-id/google-${CANINE_RODISK} ]; then',
+                  'if [ ! -b /dev/disk/by-id/google-${CANINE_RODISK} ] && gcloud compute disks describe ${CANINE_RODISK} --zone $CANINE_NODE_ZONE --format "csv(users)[no-heading]" | grep \'^http\' | grep -q $CANINE_NODE_NAME\'$\'; then',
                     'sudo touch /.fatal_disk_issue_sentinel',
                     'echo "Node cannot attach disk; node is likely bad. Tagging for deletion." >&2',
                     'exit 1',

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -878,6 +878,7 @@ class AbstractLocalizer(abc.ABC):
             'if ! mountpoint -q "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"; then',
             'sudo timeout -k 30 30 mount -o discard,defaults /dev/disk/by-id/google-"${GCP_DISK_NAME}" "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
             'sudo chown $(id -u):$(id -g) "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
+            'sudo chmod 774 "${GCP_TSNT_DISKS_DIR}/${GCP_DISK_NAME}"',
             'fi',
 
             ## lock the disk

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -872,20 +872,9 @@ class AbstractLocalizer(abc.ABC):
             'flock -os "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME" sleep infinity & echo $! >> ${CANINE_JOB_INPUTS}/.scratchdisk_lock_pids',
         ]
 
-        # if we are creating a scratch disk (which will be accessed via
-        # the task container), we need to mount the scratch disk on the host VM,
-        # in addition to inside the Slurm worker VM (same code as mounting RODISK
-        # in job_setup_teardown)
         # scratch disks dynamically resize as they get full.
         # if disk has <30% free space remaining, increase its size by 60%
         if is_scratch_disk:
-#            localization_script += [
-#              "if [[ -f /.dockerenv ]]; then",
-#              'if ! mountpoint -q "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"; then',
-#              'sudo nsenter -t 1 -m mount -o noload,defaults /dev/disk/by-id/google-${GCP_DISK_NAME} "$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME"',
-#              'fi',
-#              'fi',
-#            ]
             localization_script += [
               'cat <<EOF > $CANINE_JOB_ROOT/.diskresizedaemon.sh',
               'DISK_DIR=$GCP_TSNT_DISKS_DIR/$GCP_DISK_NAME',

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -696,6 +696,10 @@ class Orchestrator(object):
                 return n_avoided, old_job_spec
 
             # check for preexisting jobs' outputs
+            # NOTE: this directory will not exist if the task used a scratch disk,
+            #       which implicitly disables job avoidance for scratch disks.
+            #       Scratch disk tasks will avoid via a different method by having the 
+            #       localizer exit early.
             if transport.exists(localizer.staging_dir):
                 try:
                     js_df = pd.DataFrame.from_dict(self.job_spec, orient = "index").rename_axis(index = "_job_id") 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'google-crc32c>=1.5.0',
         'google-cloud-compute>=1.6.1',
         #'slurm_gcp_docker>=0.12',
-        'slurm_gcp_docker @ git+https://github.com/getzlab/slurm_gcp_docker@v0.14.1',
+        'slurm_gcp_docker @ git+https://github.com/getzlab/slurm_gcp_docker@v0.14.2',
     ],
     python_requires = ">3.7",
     classifiers = [


### PR DESCRIPTION
* File name mangling respects file extensions in tandem with indices, e.g. `x.bam`/`x.bai` -> `x_1.bam`/`x_1.bai`, rather than  `x.bam_1`/`x.bai_1`
* Finished scratch disks get mounted read-only, and script is skipped (scratch disk avoidance) 
* Add separate logic for waiting for localization disks to finish vs. scratch disks
* Run disk mount timeouts with `-k 30` to send a `SIGKILL` if mount is so stuck it doesn't respond to `SIGTERM`
* Put `r[ow]disk` mountpoints on nodes, rather than on NFS
* Don't recursively chmod files on scratch disk; just chown/chmod mountpoint after mounting