### PR TITLE
Suspend job that's been preempted too often

### DIFF
--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -44,10 +44,15 @@ export CANINE="{version}"
 export CANINE_BACKEND="{{backend}}"
 export CANINE_ADAPTER="{{adapter}}"
 export CANINE_RETRY_LIMIT={{retry_limit}}
+export CANINE_PREEMPT_LIMIT=5 # hardcoded to 5 for now, since preemptible VMs are ~1/5 the cost of nonpreemptible
 export CANINE_ROOT="{{CANINE_ROOT}}"
 export CANINE_COMMON="{{CANINE_COMMON}}"
 export CANINE_OUTPUT="{{CANINE_OUTPUT}}"
 export CANINE_JOBS="{{CANINE_JOBS}}"
+if [ ${{{{SLURM_RESTART_COUNT:-0}}}} -ge $CANINE_PREEMPT_LIMIT ]; then
+  echo "Preemption limit exceeded; suspending job for requeue on non-preemptible nodes" >&2
+  sudo -E scontrol suspend $SLURM_JOB_ID
+fi
 echo -n '---- STARTING JOB SETUP ... ' >&2
 source $CANINE_JOBS/$SLURM_ARRAY_TASK_ID/setup.sh
 rm -f $CANINE_JOB_ROOT/.*exit_code || :


### PR DESCRIPTION
Note that Slurm does not distinguish between preemptions and jobs that were manually requeued (due to failed exit state). Preemption limit must be higher than retry limit, since excess manual requeues would cause job to be resubmitted to nonpreemptible partition, which resets retry count.