### PR TITLE
Fix localization retry

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -841,7 +841,7 @@ class AbstractLocalizer(abc.ABC):
                     '[ $TRIES -ge 120 ] && { echo "Exceeded timeout waiting for another node to finish making scratch disk" >&2; exit 1; } || :',
                     '((++TRIES))',
                   'done',
-                  'exit 1 #DEBUG_OMIT', # fail localizer -> requeue task -> job avoid 
+                  'exit 1 #DEBUG_OMIT', # fail localizer -> retry task via Prefect -> job avoid. TODO: should this be exit code 5 (fail localizer -> auto-requeue via slurm?)
                 'fi',
               'fi',
               # TODO: what if the task exited on the other

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -1329,7 +1329,7 @@ class AbstractLocalizer(abc.ABC):
               # if other processes are still using it
               "flock -os ${CANINE_RODISK_DIR} sleep infinity & echo $! >> ${CANINE_JOB_INPUTS}/.rodisk_lock_pids",
 
-              'echo "Successfully attached read-only disk ${CANINE_RODISK} ..." >&2',
+              'echo "Successfully attached read-only disk ${CANINE_RODISK}." >&2',
 
               "done",
             ]

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -1310,7 +1310,7 @@ class AbstractLocalizer(abc.ABC):
               "done",
 
               # mount within Slurm worker container
-              "sudo timeout -k 30 30 mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} || { [ $? == 5 ] && exit 5 || true; }",
+              "sudo timeout -k 30 30 mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} || true",
               "fi",
 
               # because we forced zero exits for the previous commands,

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -1314,10 +1314,6 @@ class AbstractLocalizer(abc.ABC):
 
               # mount within Slurm worker container
               "sudo timeout -k 30 30 mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || { [ $? == 5 ] && exit 5 || true; }",
-#              # mount on host (so that task dockers can access it)
-#              "if [[ -f /.dockerenv ]]; then",
-#              "sudo nsenter -t 1 -m mount -o noload,ro,defaults /dev/disk/by-id/google-${CANINE_RODISK} ${CANINE_RODISK_DIR} &>> $DIAG_FILE || true",
-#              "fi",
               "fi",
 
               # because we forced zero exits for the previous commands,
@@ -1429,10 +1425,6 @@ class AbstractLocalizer(abc.ABC):
                 '  CANINE_RODISK_DIR=CANINE_RODISK_DIR_${i}',
                 '  CANINE_RODISK_DIR=${!CANINE_RODISK_DIR}',
                 '  if flock -n ${CANINE_RODISK_DIR} true && mountpoint -q ${CANINE_RODISK_DIR} && sudo umount ${CANINE_RODISK_DIR}; then',
-#                # unmount on container host too
-#                '    if [[ -f /.dockerenv ]]; then',
-#                '      sudo nsenter -t 1 -m umount ${CANINE_RODISK_DIR} || true',
-#                '    fi',
                 '    gcloud compute instances detach-disk $CANINE_NODE_NAME --zone $CANINE_NODE_ZONE --disk $CANINE_RODISK || echo "Error detaching disk ${CANINE_RODISK}" >&2',
                 '  else',
                 '    echo "RODISK ${CANINE_RODISK} is busy and will not be unmounted during teardown. It is likely in use by another job." >&2',

--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -1322,7 +1322,7 @@ class AbstractLocalizer(abc.ABC):
               "mountpoint -q ${CANINE_RODISK_DIR} || { echo 'Read-only disk mount failed!' >&2; exit 1; }",
 
               # also verify that the filesystem is OK
-              "timeout -k 30 30 ls ${CANINE_RODISK_DIR} > /dev/null || { echo 'Read-only disk mount is bad!' >&2; exit 1; }",
+              "timeout -k 30 30 ls ${CANINE_RODISK_DIR} > /dev/null || { echo 'Read-only disk mount is bad!' >&2; exit 5; }",
 
               # lock the disk; will be unlocked during teardown script (or if script crashes)
               # this is to ensure that we don't unmount the disk during teardown

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -778,8 +778,8 @@ class Orchestrator(object):
 
                     n_avoided += (js_df["noop"] | js_df["re_deloc"]).sum()
                 except (ValueError, OSError) as e:
-                    canine_logging.warning("Cannot recover preexisting task outputs: " + str(e))
-                    canine_logging.warning("Overwriting output and aborting job avoidance.")
+                    canine_logging.debug("Cannot recover preexisting task outputs: " + str(e))
+                    canine_logging.debug("Overwriting output and aborting job avoidance.")
                     self.job_spec = old_job_spec
                     transport.rmtree(localizer.staging_dir)
                     transport.makedirs(localizer.staging_dir)

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -96,7 +96,12 @@ if [ $LOCALIZER_JOB_RC -eq 0 ]; then
     fi
   done
   echo -n $CANINE_JOB_RC > $CANINE_JOB_ROOT/.job_exit_code
-elif [ $LOCALIZER_JOB_RC -eq 15 ]; then # this is a special exit code that localization.sh can explicitly return
+# these are special exit codes that localization.sh can explicitly return
+elif [ $LOCALIZER_JOB_RC -eq 5 ]; then # localization failed due to recoverable reason (e.g. quota); requeue the job
+  echo "INFO: localization will be retried" >&2
+  scontrol requeue $SLURM_JOB_ID
+  scontrol update $SLURM_JOB_ID starttime=now+10m
+elif [ $LOCALIZER_JOB_RC -eq 15 ]; then # localization can be skipped (e.g. localization disk already exists)
   echo '~~~~ LOCALIZATION SKIPPED ~~~~' >&2
   export CANINE_JOB_RC=0
   echo -n "DNR" > $CANINE_JOB_ROOT/.job_exit_code

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -100,7 +100,6 @@ if [ $LOCALIZER_JOB_RC -eq 0 ]; then
 elif [ $LOCALIZER_JOB_RC -eq 5 ]; then # localization failed due to recoverable reason (e.g. quota); requeue the job
   echo "INFO: localization will be retried" >&2
   scontrol requeue $SLURM_JOB_ID
-  scontrol update $SLURM_JOB_ID starttime=now+10m
 elif [ $LOCALIZER_JOB_RC -eq 15 ]; then # localization and job can be skipped (to facilitate avoidance of scratch disk tasks)
   echo '~~~~ LOCALIZATION SKIPPED ~~~~' >&2
   export CANINE_JOB_RC=0

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -79,6 +79,7 @@ if [ $LOCALIZER_JOB_RC -eq 0 ]; then
       echo    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
       echo -e "!!!! JOB FAILED! (EXIT CODE                 !!!!\e[29G$CANINE_JOB_RC)" >&2
       echo    "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >&2
+      echo $(($([ -f $CANINE_JOB_ROOT/.failure_count ] && cat $CANINE_JOB_ROOT/.failure_count || echo -n 0)+1)) > $CANINE_JOB_ROOT/.failure_count
       echo '++++ STARTING JOB CLEANUP ++++' >&2
       $CANINE_JOBS/$SLURM_ARRAY_TASK_ID/teardown.sh >&2
       TEARDOWN_RC=$?
@@ -91,7 +92,6 @@ if [ $LOCALIZER_JOB_RC -eq 0 ]; then
       echo "INFO: Retrying job (attempt $((${{{{SLURM_RESTART_COUNT:-0}}}}+1))/$CANINE_RETRY_LIMIT)" >&2
       [ -f $CANINE_JOB_ROOT/stdout ] && mv $CANINE_JOB_ROOT/stdout $CANINE_JOB_ROOT/stdout_${{{{SLURM_RESTART_COUNT:-0}}}} || :
       [ -f $CANINE_JOB_ROOT/stderr ] && mv $CANINE_JOB_ROOT/stderr $CANINE_JOB_ROOT/stderr_${{{{SLURM_RESTART_COUNT:-0}}}} || :
-      echo $(($([ -f $CANINE_JOB_ROOT/.failure_count ] && cat $CANINE_JOB_ROOT/.failure_count || echo -n 0)+1)) > $CANINE_JOB_ROOT/.failure_count
       scontrol requeue $SLURM_JOB_ID
     fi
   done
@@ -99,6 +99,7 @@ if [ $LOCALIZER_JOB_RC -eq 0 ]; then
 # these are special exit codes that localization.sh can explicitly return
 elif [ $LOCALIZER_JOB_RC -eq 5 ]; then # localization failed due to recoverable reason (e.g. quota); requeue the job
   echo "INFO: localization will be retried" >&2
+  echo $(($([ -f $CANINE_JOB_ROOT/.failure_count ] && cat $CANINE_JOB_ROOT/.failure_count || echo -n 0)+1)) > $CANINE_JOB_ROOT/.failure_count
   scontrol requeue $SLURM_JOB_ID
 elif [ $LOCALIZER_JOB_RC -eq 15 ]; then # localization and job can be skipped (to facilitate avoidance of scratch disk tasks)
   echo '~~~~ LOCALIZATION SKIPPED ~~~~' >&2

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -98,7 +98,7 @@ if [ $LOCALIZER_JOB_RC -eq 0 ]; then
   echo -n $CANINE_JOB_RC > $CANINE_JOB_ROOT/.job_exit_code
 # these are special exit codes that localization.sh can explicitly return
 elif [ $LOCALIZER_JOB_RC -eq 5 ]; then # localization failed due to recoverable reason (e.g. quota); requeue the job
-  echo "INFO: localization will be retried" >&2
+  echo "WARNING: localization will be retried" >&2
   echo $(($([ -f $CANINE_JOB_ROOT/.failure_count ] && cat $CANINE_JOB_ROOT/.failure_count || echo -n 0)+1)) > $CANINE_JOB_ROOT/.failure_count
   scontrol requeue $SLURM_JOB_ID
 elif [ $LOCALIZER_JOB_RC -eq 15 ]; then # localization and job can be skipped (to facilitate avoidance of scratch disk tasks)

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -101,7 +101,7 @@ elif [ $LOCALIZER_JOB_RC -eq 5 ]; then # localization failed due to recoverable 
   echo "INFO: localization will be retried" >&2
   scontrol requeue $SLURM_JOB_ID
   scontrol update $SLURM_JOB_ID starttime=now+10m
-elif [ $LOCALIZER_JOB_RC -eq 15 ]; then # localization can be skipped (e.g. localization disk already exists)
+elif [ $LOCALIZER_JOB_RC -eq 15 ]; then # localization and job can be skipped (to facilitate avoidance of scratch disk tasks)
   echo '~~~~ LOCALIZATION SKIPPED ~~~~' >&2
   export CANINE_JOB_RC=0
   echo -n "DNR" > $CANINE_JOB_ROOT/.job_exit_code


### PR DESCRIPTION
* Add special exit code 5 that causes localization to be retried (will cause task to be requeued)
* Revamp logic for waiting for other instance to finish disk (exit immediately and requeue, rather than wait — this was buggy)
* Add timeout for attaching/detaching disks, which can sometimes hang on GCP's end