### PR TITLE
Added -m flag to `gsutil cp` in GSURL file handler localization command

### DIFF
--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -224,7 +224,7 @@ class HandleGSURL(FileType):
         dest_dir = shlex.quote(os.path.dirname(dest))
         dest_file = shlex.quote(os.path.basename(dest))
         self.localized_path = os.path.join(dest_dir, dest_file)
-        return ("[ ! -d {dest_dir} ] && mkdir -p {dest_dir} || :; ".format(dest_dir = self.localized_path if self.is_dir else dest_dir)) + f'gsutil {self.rp_string} -o "GSUtil:state_dir={dest_dir}/.gsutil_state_dir" cp -r -n -L "{dest_dir}/.gsutil_manifest" {self.path} {dest_dir}/{dest_file if not self.is_dir else ""}'
+        return ("[ ! -d {dest_dir} ] && mkdir -p {dest_dir} || :; ".format(dest_dir = self.localized_path if self.is_dir else dest_dir)) + f'gsutil {self.rp_string} -m -o "GSUtil:state_dir={dest_dir}/.gsutil_state_dir" cp -r -n -L "{dest_dir}/.gsutil_manifest" {self.path} {dest_dir}/{dest_file if not self.is_dir else ""}'
 
 class HandleGSURLStream(HandleGSURL):
     localization_mode = "stream"


### PR DESCRIPTION
From the docs (https://cloud.google.com/storage/docs/gsutil/addlhelp/GlobalCommandLineOptions)

> Using the -m option can consume a significant amount of network bandwidth and cause problems or make your
> performance worse if you use a slower network. For example, if you start a large rsync operation over a network 
> link that's also used by a number of other important jobs, there could be degraded performance in those jobs. 
> Similarly, the -m option can make your performance worse, especially for cases that perform all operations 
> locally, because it can "thrash" your local disk.
> 
> To prevent such issues, reduce the values for parallel_thread_count and parallel_process_count, or stop using the 
> -m option entirely. One tool that you can use to limit how much I/O capacity gsutil consumes and prevent it from 
> monopolizing your local disk is [ionice](http://www.tutorialspoint.com/unix_commands/ionice.htm) (built in to many 
> Linux systems). 

I would guess the typical network speeds between GCP storage and compute are fast. A complete/robust solution may involve configuring the `parallel_thread_count` or `parallel_process_count`, or invoking `ionice`.

Thought I would open this PR anyways, just to get this started.