### PR TITLE
Implement DRS URI localization.

### DIFF
--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -127,7 +127,7 @@ class HandleGSURL(FileType):
         bucket = re.match(r"gs://(.*?)/.*", self.path)[1]
 
         gcs_cl = gcloud_storage_client()
-        bucket_obj = google.cloud.storage.Bucket(gcs_cl, bucket, user_project = self.extra_args["project"] if "project" in self.extra_args else None)
+        bucket_obj = google.cloud.storage.Bucket(gcs_cl, bucket, user_project = self.extra_args.get("project"))
 
         return bucket_obj.requester_pays
 
@@ -170,7 +170,7 @@ class HandleGSURL(FileType):
 
         gcs_cl = gcloud_storage_client()
 
-        bucket_obj = google.cloud.storage.Bucket(gcs_cl, bucket, user_project = self.extra_args["project"] if "project" in self.extra_args else None)
+        bucket_obj = google.cloud.storage.Bucket(gcs_cl, bucket, user_project = self.extra_args.get("project"))
 
         # check whether this path exists, and whether it's a directory
         exists = False
@@ -283,13 +283,13 @@ class HandleAWSURL(FileType):
 
         # keys get passed via environment variable
         self.command_env = {}
-        self.command_env["AWS_ACCESS_KEY_ID"] = self.extra_args["aws_access_key_id"] if "aws_access_key_id" in self.extra_args else None 
-        self.command_env["AWS_SECRET_ACCESS_KEY"] = self.extra_args["aws_secret_access_key"] if "aws_secret_access_key" in self.extra_args else None 
+        self.command_env["AWS_ACCESS_KEY_ID"] = self.extra_args.get("aws_access_key_id")
+        self.command_env["AWS_SECRET_ACCESS_KEY"] = self.extra_args.get("aws_secret_access_key")
         self.command_env_str = " ".join([f"{k}={v}" for k, v in self.command_env.items() if v is not None])
 
         # compute extra arguments for s3 commands
         # TODO: add requester pays check here
-        self.aws_endpoint_url = self.extra_args["aws_endpoint_url"] if "aws_endpoint_url" in self.extra_args else None 
+        self.aws_endpoint_url = self.extra_args.get("aws_endpoint_url")
 
         self.s3_extra_args = []
         if self.command_env["AWS_ACCESS_KEY_ID"] is None and self.command_env["AWS_SECRET_ACCESS_KEY"] is None:
@@ -400,9 +400,9 @@ class HandleGDCHTTPURL(FileType):
     def __init__(self, path, **kwargs):
         super().__init__(path, **kwargs)
 
-        self.token = self.extra_args["token"] if "token" in self.extra_args else None 
+        self.token = self.extra_args.get("token")
         self.token_flag = f'--header  "X-Auth-Token: {self.token}"' if self.token is not None else ''
-        self.check_md5 = self.extra_args["check_md5"] if "check_md5" in self.extra_args else False
+        self.check_md5 = self.extra_args.get("check_md5", False)
 
         # parse URL
         self.url = self.path
@@ -505,7 +505,7 @@ class HandleDRSURI(FileType):
     def __init__(self, path, **kwargs):
         super().__init__(path, **kwargs)
 
-        self.check_md5 = self.extra_args["check_md5"] if "check_md5" in self.extra_args else False
+        self.check_md5 = self.extra_args.get("check_md5", False)
 
         # parse URL
         self.uri = self.path

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -521,7 +521,7 @@ class HandleDRSURI(FileType):
 
         drshub_session = gcp_auth_session()
         resp = drshub_session.post(type(self).drs_resolver,
-                                   headers={"Content-type": "application/json"}, data=data)
+                                   headers={"Content-type": "application/json"}, json=data)
 
         try:
             metadata = resp.json()

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -585,9 +585,10 @@ class HandleDRSURIStream(HandleDRSURI):
                      '-H "authorization: Bearer $(gcloud auth print-access-token)" ' + \
                      f'-H "content-type: application/json" --data \'{data_str}\' | ' + \
                      'python3 -c \'import json,sys; print(json.load(sys.stdin)["accessUrl"]["url"])\')'
+        cmd += [f'signed_url={signed_url}']
 
         # stream into fifo object
-        cmd += ['curl -C - -o {path} "{url}" &'.format(path=self.localized_path, url=signed_url)]
+        cmd += ['curl -C - -o {path} "$signed_url" &'.format(path=self.localized_path)]
 
         return "\n".join(cmd)
 

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -445,15 +445,11 @@ class HandleGDCHTTPURL(FileType):
                 canine_logging.error("Error resolving GDC file; see details:")
                 canine_logging.error(resp_headers.stdout.decode())
                 raise
-        if self.drs_obj is not None:
-            self.path = self.drs_obj.path
-            self._size = self.drs_obj.size
-            self._hash = self.drs_obj.hash
-            self.url = self.drs_obj.url
-            self.token = None
         self.localized_path = self.path
 
     def localization_command(self, dest):
+        if self.drs_obj is not None:
+            return self.drs_obj.localization_command(dest)
         dest_dir = shlex.quote(os.path.dirname(dest))
         dest_file = shlex.quote(os.path.basename(dest))
         self.localized_path = os.path.join(dest_dir, dest_file)

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -445,6 +445,13 @@ class HandleGDCHTTPURL(FileType):
                 canine_logging.error("Error resolving GDC file; see details:")
                 canine_logging.error(resp_headers.stdout.decode())
                 raise
+        if self.drs_obj is not None:
+            # if we have a DRS object, use its properties
+            self.path = self.drs_obj.path
+            self._size = self.drs_obj.size
+            self._hash = self.drs_obj.hash
+            self.url = self.drs_obj.uri
+            self.token = None
         self.localized_path = self.path
 
     def localization_command(self, dest):

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -242,6 +242,8 @@ class HandleGSURLStream(HandleGSURL):
         )])
 
 # }}}
+class GSFileNotExists(Exception):
+    pass
 
 ## GCP Authorized Session {{{
 
@@ -259,8 +261,6 @@ def gcp_auth_session():
     return GCP_AUTH_SESSION
 
 # }}}
-class GSFileNotExists(Exception):
-    pass
 
 ## AWS S3 {{{
 

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -718,8 +718,9 @@ class HandleRODISKURL(FileType):
 
 def get_file_handler(path, url_map = None, **kwargs):
     url_map = {
-      r"^gs://" : HandleGSURL, 
-      r"^s3://" : HandleAWSURL, 
+      r"^gs://" : HandleGSURL,
+      r"^s3://" : HandleAWSURL,
+      r"^drs://" : HandleDRSURI,
       r"^https://api.gdc.cancer.gov" : HandleGDCHTTPURL,
       r"^https://api.awg.gdc.cancer.gov" : HandleGDCHTTPURL,
       r"^rodisk://" : HandleRODISKURL,

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -242,8 +242,6 @@ class HandleGSURLStream(HandleGSURL):
         )])
 
 # }}}
-class GSFileNotExists(Exception):
-    pass
 
 ## GCP Authorized Session {{{
 

--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -544,7 +544,7 @@ class HandleDRSURI(FileType):
         dest_file = shlex.quote(os.path.basename(dest))
         self.localized_path = os.path.join(dest_dir, dest_file)
         data_str = json.dumps({"url": self.uri, "fields": ["accessUrl"]})
-        signed_url = f'$(curl -S -X POST --url {type(self).drs_resolver} ' + \
+        signed_url = f'$(curl -S -X POST --url "{type(self).drs_resolver}" ' + \
                      '-H "authorization: Bearer $(gcloud auth print-access-token)" ' + \
                      f'-H "content-type: application/json" --data \'{data_str}\' | ' + \
                      'python3 -c \'import json,sys; print(json.load(sys.stdin)["accessUrl"]["url"])\')'
@@ -578,7 +578,7 @@ class HandleDRSURIStream(HandleDRSURI):
 
         # get signed URL
         data_str = json.dumps({"url": self.uri, "fields": ["accessUrl"]})
-        signed_url = f'$(curl -S -X POST --url {type(self).drs_resolver} ' + \
+        signed_url = f'$(curl -S -X POST --url "{type(self).drs_resolver}" ' + \
                      '-H "authorization: Bearer $(gcloud auth print-access-token)" ' + \
                      f'-H "content-type: application/json" --data \'{data_str}\' | ' + \
                      'python3 -c \'import json,sys; print(json.load(sys.stdin)["accessUrl"]["url"])\')'

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.15.5'
+version = '0.15.6'
 
 ADAPTERS = {
     'Manual': ManualAdapter,


### PR DESCRIPTION
Update to use DRS URIs, and attempt to use them on detecting GDC API URLs.

This feature takes advantage of Terra's [DRSHub](https://drshub.dsde-prod.broadinstitute.org/). So long as the user is using the same account they registered with to [Terra](app.terra.bio), and has their external identities properly linked in their [profile](https://app.terra.bio/#profile?tab=externalIdentities), this will enable acquiring signed URLs for data download, which is several times quicker than downloading via the GDC API.

This also improves compatibility with Terra workspaces, which may use DRS URIs in place of bucket paths.