### PR TITLE
Improved delocalization checksum

### DIFF
--- a/canine/localization/delocalization.py
+++ b/canine/localization/delocalization.py
@@ -94,8 +94,7 @@ def compute_crc32c(path, fast = False):
     hash_alg = google_crc32c.Checksum()
     ct = 0
     for f, n_u in zip(files, n_updates):
-        if ct % 100 == 0:
-            print(f"Hashing file {f}; {ct}/{total_updates} hashes computed", file = sys.stderr, flush = True)
+        print(f"Hashing file {f}; {ct}/{total_updates} hashes computed", file = sys.stderr, flush = True)
 
         with open(f, "rb") as fp:
             for i in range(n_u):
@@ -103,6 +102,8 @@ def compute_crc32c(path, fast = False):
                 data = fp.read(buffer_size)
                 hash_alg.update(data)
                 ct += 1
+                if ct % 100 == 0:
+                    print(f"Hashing file {f}; {ct}/{total_updates} hashes computed", file = sys.stderr, flush = True)
 
     return hash_alg.hexdigest().decode().upper()
 


### PR DESCRIPTION
The previous checksum method in `canine/localization/delocalization.py` had some problematic worst-case behaviors.

Specifically: imagine a task that outputs a **directory** containing hundreds of large files (~900MB). In this case, the checksum method would fully hash every one of these files; and it would do so serially. This output hashing could take several hours, dwarfing the expense of the actual compute task.

(It turns out this scenario is all too real when working with single cell data!)

This PR contains a new checksum method that allocates at most `max(number_of_files, 1024)` checksum updates to a task output. If an output is a single file, then it works much the same as before. If an output is a directory, then the checksum updates are allocated to files such that (A) each file is given at least one checksum update and (B) files are given checksum updates in rough proportion to their sizes.

This circumvents problematic worst-case expense -- hashing never takes more than a few seconds now.