### PR TITLE
Replaced almost all gsutil calls with gcloud storage

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -178,7 +178,7 @@ class AbstractLocalizer(abc.ABC):
                 # Try again ls-ing the object itself
                 # sometimes permissions can disallow bucket inspection
                 # but allow object inspection
-                command = 'gsutil ls gs://{}'.format(path)
+                command = 'gcloud storage ls gs://{}'.format(path)
                 rc, sout, serr = self.backend.invoke(command)
                 text = serr.read()
                 self.requester_pays[bucket] = b'requester pays bucket but no user project provided' in text
@@ -192,8 +192,8 @@ class AbstractLocalizer(abc.ABC):
         Returns the total number of bytes of the given gsutil object.
         If a directory is given, this will return the total space used by all objects in the directory
         """
-        cmd = 'gsutil {} du -s {}'.format(
-            '-u {}'.format(self.project) if self.get_requester_pays(path) else '',
+        cmd = 'gcloud storage {} du -s {}'.format(
+            '--billing-project={}'.format(self.project) if self.get_requester_pays(path) else '',
             path
         )
         rc, sout, serr = self.backend.invoke(cmd)
@@ -263,8 +263,8 @@ class AbstractLocalizer(abc.ABC):
                 self.backend.invoke('touch {}/.canine_dir_marker'.format(src))
             else:
                 subprocess.run(['touch', '{}/.canine_dir_marker'.format(src)])
-        command = "gsutil -m -o GSUtil:check_hashes=if_fast_else_skip -o GSUtil:parallel_composite_upload_threshold=150M {} cp -r {} {}".format(
-            '-u {}'.format(self.project) if self.get_requester_pays(gs_obj) else '',
+        command = "gcloud config set storage/check_hashes if_fast_else_skip && gcloud config set storage/parallel_composite_upload_threshold 150M && gcloud storage {} cp -r {} {}".format(
+            '--billing-project={}'.format(self.project) if self.get_requester_pays(gs_obj) else '',
             src,
             dest
         )
@@ -308,8 +308,8 @@ class AbstractLocalizer(abc.ABC):
             # Procede as a regular gs_copy
             traceback.print_exc()
 
-        command = "gsutil -o GSUtil:check_hashes=if_fast_else_skip -o GSUtil:parallel_composite_upload_threshold=150M {} cp {} {}".format(
-            '-u {}'.format(self.project) if self.get_requester_pays(gs_obj) else '',
+        command = "gcloud config set storage/check_hashes if_fast_else_skip && gcloud config set storage/parallel_composite_upload_threshold 150M && gcloud storage {} cp {} {}".format(
+            '--billing-project={}'.format(self.project) if self.get_requester_pays(gs_obj) else '',
             src,
             dest
         )
@@ -361,8 +361,8 @@ class AbstractLocalizer(abc.ABC):
                         file=sys.stderr, type = "error"
                     )
                     raise
-                cmd = "gsutil -m {} rm -r gs://{}/{}".format(
-                    '-u {}'.format(self.project) if self.get_requester_pays(self.transfer_bucket) else '',
+                cmd = "gcloud storage {} rm -r gs://{}/{}".format(
+                    '--billing-project={}'.format(self.project) if self.get_requester_pays(self.transfer_bucket) else '',
                     self.transfer_bucket,
                     os.path.dirname(path),
                 )
@@ -417,8 +417,8 @@ class AbstractLocalizer(abc.ABC):
                         file=sys.stderr, type="error"
                     )
                     raise
-                cmd = "gsutil -m {} rm -r gs://{}/{}".format(
-                    '-u {}'.format(self.project) if self.get_requester_pays(self.transfer_bucket) else '',
+                cmd = "gcloud storage {} rm -r gs://{}/{}".format(
+                    '--billing-project={}'.format(self.project) if self.get_requester_pays(self.transfer_bucket) else '',
                     self.transfer_bucket,
                     os.path.dirname(path),
                 )

--- a/canine/test/test_localizer_batched.py
+++ b/canine/test/test_localizer_batched.py
@@ -307,7 +307,7 @@ class TestIntegration(unittest.TestCase):
                                         self.assertIn(
                                             'if [[ -e {dest} ]]; then rm {dest}; fi\n'
                                             'mkfifo {dest}\n'
-                                            'gsutil  cat {src} > {dest} &'.format(
+                                            'gcloud storage cat {src} > {dest} &'.format(
                                                 src=src,
                                                 dest=path
                                             ),
@@ -317,9 +317,9 @@ class TestIntegration(unittest.TestCase):
                                         src = path
                                         path = localizer.reserve_path('jobs', str(jid), 'inputs', os.path.basename(os.path.abspath(src))).remotepath
                                         self.assertIn(
-                                            'if [[ ! -e {dest}.fin ]]; then gsutil  '
-                                            '-o GSUtil:check_hashes=if_fast_else_skip'
-                                            ' cp {src} {dest} && touch {dest}.fin'.format(
+                                            'if [[ ! -e {dest}.fin ]]; then gcloud config '
+                                            'set storage/check_hashes if_fast_else_skip &&'
+                                            ' gcloud storage cp {src} {dest} && touch {dest}.fin'.format(
                                                 src=src,
                                                 dest=path
                                             ),


### PR DESCRIPTION
Almost all gsutil references have been replaced. Some differences to note:
-u flag has been replaced with --billing-project. These translate directly.
-m flag has been removed. This is done automatically in gcloud.
-o flag has been replaced by separate commands that change the local gcloud configuration - I was not able to find any way to change it just for a specific command. I do not change the configuration back to the default after the command is done, it is my understanding that it is not necessary due to the compartmentalization of tasks.

I was able to find a command somewhat analogous to gsutil requesterpays, but the return format is different enough that I didn't want to change it without a good way to test it. That's the one gsutil call that didn't get changed.