### PR TITLE
Update file_handlers.py get_requester_pays

### DIFF
--- a/canine/localization/file_handlers.py
+++ b/canine/localization/file_handlers.py
@@ -128,7 +128,7 @@ class HandleGSURL(FileType):
 
         gcs_cl = gcloud_storage_client()
         bucket_obj = google.cloud.storage.Bucket(gcs_cl, bucket, user_project = self.extra_args.get("project"))
-
+        bucket_obj.reload() 
         return bucket_obj.requester_pays
 
 # TODO: handle case where permissions disallow bucket inspection?


### PR DESCRIPTION
## Problem
get_requester_pays() is incorrectly returning False for buckets that are requester-pays. I copied this code block from canine into my notebook for testing: 
https://github.com/getzlab/canine/blob/0cebe1915181800bbd342043c414f032ada149db/canine/localization/file_handlers.py#L108-L132

Here we see `bucket._properties` is empty,  which is why this returns false.
<img width="815" alt="image" src="https://github.com/user-attachments/assets/657de6a4-9139-43f9-af72-ee1cff5ae0de">


## Solutions
Google's API suggests a different approach: https://cloud.google.com/storage/docs/using-requester-pays#storage-get-requester-pays-status-python

`bucket.reload()` is used in google's own API above: https://github.com/googleapis/python-storage/blob/e3cfc4786209c77e3c879c9ff2978f4884a0d677/google/cloud/storage/client.py#L870-L877

When I add `bucket.reload()`, we get the expected behavior (with the `_properties` attribute filled):
<img width="788" alt="image" src="https://github.com/user-attachments/assets/b1d86ca0-4ab6-4fef-91cc-2045f09b1238">

Alternatively, we use Google's recommended approach directly:
<img width="558" alt="image" src="https://github.com/user-attachments/assets/42e2e7e2-cab8-457c-bc56-7b8e6ae59498">



