### PR TITLE
Fix disk size calc

### DIFF
--- a/canine/localization/base.py
+++ b/canine/localization/base.py
@@ -728,7 +728,7 @@ class AbstractLocalizer(abc.ABC):
             #There used to be a bug here: Note that GB is 10^9, while gibibyte is 2^30, so when 
             #a disk is allocated in google cloud, the size is in GB. So, don't divide the size by
             #0.95*2**30 (as was done before) but instead with 0.95*10**9
-            disk_size = max(10, 1 + int(disk_size / (0.95*10**9))) # bytes -> gib with 5% safety margin
+            disk_size = max(10, 1 + int(disk_size / (0.95*10**9))) # bytes -> gigabytes (not gibibytes) with 5% safety margin
 
             ## Save RODISK paths for subsequent use by downstream tasks
             rodisk_paths = F.loc[F["localize"], :].groupby("input")["disk_path"].apply(list).to_dict()
@@ -1051,7 +1051,7 @@ class AbstractLocalizer(abc.ABC):
             #0.95*2**30 (as was done before) but instead with 0.95*10**9
             local_download_size = max(
                 10,
-                1+int(local_download_size / (0.95*10**9)) # bytes -> gib with 5% safety margin
+                1+int(local_download_size / (0.95*10**9)) # bytes -> gigabytes (not gibibytes) with 5% safety margin
             )
             if local_download_size > 65535:
                 raise ValueError("Cannot provision {} GB disk for job {}".format(local_download_size, jobId))

--- a/canine/orchestrator.py
+++ b/canine/orchestrator.py
@@ -14,7 +14,7 @@ import yaml
 import numpy as np
 import pandas as pd
 from agutil import status_bar
-version = '0.16.0'
+version = '0.16.1'
 
 ADAPTERS = {
     'Manual': ManualAdapter,


### PR DESCRIPTION
Disk size for localization was calculated assuming that the size in google cloud is based on Gibibytes (Gb) (2^30), while the size is instead in Gigabytes (GB) (10^9). This lead to an underestimation of the disk size and consequently problems with some disks during relocalization, leading to a lot of errors when running pipelines in wolF. It could be questioned if we should have a 5% margin on the size, it is probably more than needed, but it is robust and safe at least, and I guess disk is cheap compared to compute, since we keep these for a short time only. This will lead to less problems with the pipeline.